### PR TITLE
DSCO-2755: [Prism] NavBar not full bleed

### DIFF
--- a/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
@@ -224,7 +224,6 @@ exports[`NavBar renders fixed 1`] = `
 
 .c1 {
   width: 100%;
-  max-width: 1440px;
   height: 60px;
   position: relative;
   display: -webkit-box;
@@ -283,6 +282,12 @@ exports[`NavBar renders fixed 1`] = `
 @media screen and (min-width:769px) {
   .c1 {
     margin: 0 auto;
+  }
+}
+
+@media (min-width:1440px) {
+  .c1 {
+    padding: 0 44px;
   }
 }
 
@@ -656,7 +661,6 @@ exports[`NavBar renders inverted 1`] = `
 
 .c1 {
   width: 100%;
-  max-width: 1440px;
   height: 60px;
   position: relative;
   display: -webkit-box;
@@ -715,6 +719,12 @@ exports[`NavBar renders inverted 1`] = `
 @media screen and (min-width:769px) {
   .c1 {
     margin: 0 auto;
+  }
+}
+
+@media (min-width:1440px) {
+  .c1 {
+    padding: 0 44px;
   }
 }
 
@@ -1133,7 +1143,6 @@ exports[`NavBar renders with defaults 1`] = `
 
 .c1 {
   width: 100%;
-  max-width: 1440px;
   height: 60px;
   position: relative;
   display: -webkit-box;
@@ -1193,6 +1202,12 @@ exports[`NavBar renders with defaults 1`] = `
 @media screen and (min-width:769px) {
   .c1 {
     margin: 0 auto;
+  }
+}
+
+@media (min-width:1440px) {
+  .c1 {
+    padding: 0 44px;
   }
 }
 

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -5,6 +5,7 @@ import classNames from "classnames";
 
 import colors from "../../theme/colors";
 import spacing from "../../theme/spacing";
+import constants from "../../theme/constants";
 import typography from "../../theme/typography";
 import { mediumAndUp, largeAndUp } from "../../theme/mediaQueries";
 
@@ -79,7 +80,6 @@ const Nav = styled.nav.attrs({
 
 const Container = styled.div`
   width: 100%;
-  max-width: 1440px;
   height: 60px;
   position: relative;
   display: flex;
@@ -91,6 +91,10 @@ const Container = styled.div`
   ${largeAndUp`
     margin: 0 auto;
   `};
+
+  @media ${constants.breakpoints.xLarge} {
+    padding: 0 44px;
+  }
 `;
 
 const Right = styled.div`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**Ticket**: [[Prism] NavBar not full bleed](https://contegixapp1.livenation.com/jira/browse/DSCO-2755)

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Remove `max-width: 1440px` from `NavBar` `Container`

<!-- Why are these changes necessary? -->

**Why**: To spread `NavBar` contents to full bleed on large screen sizes

<!-- How were these changes implemented? -->

**How**: Remove `max-width: 1440px` from `NavBar` `Container` 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
