### PR TITLE
DSCO-2756: [Prism] NavBar wraps to two lines

### DIFF
--- a/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/NavBar/__tests__/__snapshots__/index.spec.js.snap
@@ -1394,3 +1394,81 @@ exports[`NavBar renders with defaults 1`] = `
   </div>
 </nav>
 `;
+
+exports[`NavBar.Left renders correctly with valid style and children props pased 1`] = `
+.c0 {
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  width: 310px;
+  min-width: 310px;
+  max-width: 310px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 60px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-left: 12px;
+}
+
+@media screen and (min-width:769px) {
+  .c0 {
+    width: 50%;
+  }
+}
+
+<div
+  className="c0"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
+>
+  Contents
+</div>
+`;
+
+exports[`NavBar.Right renders correctly with valid style and children props pased 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  height: 60px;
+}
+
+@media screen and (min-width:481px) {
+  .c0 {
+    width: 23%;
+  }
+}
+
+@media screen and (min-width:769px) {
+  .c0 {
+    width: 18%;
+  }
+}
+
+<div
+  className="c0"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
+>
+  Contents
+</div>
+`;

--- a/src/components/NavBar/__tests__/index.spec.js
+++ b/src/components/NavBar/__tests__/index.spec.js
@@ -87,3 +87,25 @@ describe("NavBar", () => {
         .toJSON()
     ).toMatchSnapshot());
 });
+
+describe("NavBar.Right", () => {
+  it("renders correctly with valid style and children props pased", () => {
+    expect(
+      renderer
+        .create(
+          <NavBar.Right style={{ display: "flex" }}>Contents</NavBar.Right>
+        )
+        .toJSON()
+    ).toMatchSnapshot();
+  });
+});
+
+describe("NavBar.Left", () => {
+  it("renders correctly with valid style and children props pased", () => {
+    expect(
+      renderer
+        .create(<NavBar.Left style={{ display: "flex" }}>Contents</NavBar.Left>)
+        .toJSON()
+    ).toMatchSnapshot();
+  });
+});

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -102,6 +102,19 @@ const Right = styled.div`
   ${largeAndUp`width: 18%;`};
 `;
 
+const RightWrapper = ({ children, style }) => (
+  <Right style={style}>{children}</Right>
+);
+
+RightWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  style: PropTypes.objectOf(PropTypes.string)
+};
+
+RightWrapper.defaultProps = {
+  style: {}
+};
+
 const Left = styled.div`
   flex: 0 1 auto;
   width: 310px;
@@ -113,6 +126,19 @@ const Left = styled.div`
   padding-left: ${parseInt(spacing.normal, 10) / 2}px;
   ${largeAndUp`width: 50%;`};
 `;
+
+const LeftWrapper = ({ children, style }) => (
+  <Left style={style}>{children}</Left>
+);
+
+LeftWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  style: PropTypes.objectOf(PropTypes.string)
+};
+
+LeftWrapper.defaultProps = {
+  style: {}
+};
 
 const MessageContainer = GridContainer.extend`
   background-color: rgba(0, 0, 0, 0.2);
@@ -182,8 +208,8 @@ NavBar.TextButton = Buttons.TextButton;
 NavBar.LinkRow = Links.LinkRow;
 NavBar.LinkList = Links.LinkList;
 NavBar.Link = Links.Link;
-NavBar.Right = Right;
-NavBar.Left = Left;
+NavBar.Right = RightWrapper;
+NavBar.Left = LeftWrapper;
 NavBar.LogoContainer = Buttons.LogoContainer;
 
 export default NavBar;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**Ticket**: [[Prism] NavBar wraps to two lines](https://contegixapp1.livenation.com/jira/browse/DSCO-2756)
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Create and test `RightWrapper` and `LeftWrapper` components to enable passing through of style props.

<!-- Why are these changes necessary? -->

**Why**:  The developer should be able to configure `NavBar.Right` and `NavBar.Left` styles beyond the out-of-box design, given a particular application context.

<!-- How were these changes implemented? -->

**How**: Create and test `RightWrapper` and `LeftWrapper` components to enable passing through of style props.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [X] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
