### PR TITLE
DSCO-2653: chore(Breakpoint) Add xSmall breakpoint and DeviceSizeProvider support

### DIFF
--- a/src/components/DeviceSize/Provider.js
+++ b/src/components/DeviceSize/Provider.js
@@ -30,10 +30,12 @@ export default class DeviceSizeProvider extends React.Component {
       return;
     }
 
+    this.xSmallMedia = window.matchMedia(constants.breakpoints.xSmall);
     this.smallMedia = window.matchMedia(constants.breakpoints.small);
     this.mediumMedia = window.matchMedia(constants.breakpoints.medium);
     this.largeMedia = window.matchMedia(constants.breakpoints.large);
     this.xLargeMedia = window.matchMedia(constants.breakpoints.xLarge);
+    this.xSmallMedia.addListener(this.setSize);
     this.smallMedia.addListener(this.setSize);
     this.mediumMedia.addListener(this.setSize);
     this.largeMedia.addListener(this.setSize);
@@ -58,6 +60,7 @@ export default class DeviceSizeProvider extends React.Component {
     }
 
     this.setState(() => ({
+      isXSmall: this.xSmallMedia.matches && !this.smallMedia.matches,
       isSmall: this.smallMedia.matches,
       isMedium: this.mediumMedia.matches && !this.largeMedia.matches,
       isLarge: this.largeMedia.matches && !this.xLargeMedia.matches,
@@ -67,6 +70,7 @@ export default class DeviceSizeProvider extends React.Component {
   };
 
   unsubscribe = () => {
+    if (this.xSmallMedia) this.xSmallMedia.removeListener(this.setSize);
     if (this.smallMedia) this.smallMedia.removeListener(this.setSize);
     if (this.mediumMedia) this.mediumMedia.removeListener(this.setSize);
     if (this.largeMedia) this.largeMedia.removeListener(this.setSize);

--- a/src/theme/constants.js
+++ b/src/theme/constants.js
@@ -5,6 +5,7 @@ const constants = {
     large: "4px"
   },
   breakpoints: {
+    xSmall: "(max-width: 321px)",
     small: "(max-width: 767px)",
     medium: "(min-width: 768px)",
     large: "(min-width: 1024px)",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add `xSmall` breakpoint and `DeviceSizeProvider` support.

<!-- Why are these changes necessary? -->

**Why**: Ensure we an easily change UI to accommodate `xSmall` devices using the `DeviceSizeProvider/Consumer` pattern. Specifically, I plan to introduce this breakpoint in `next-renderer` to rectify the cut-off sign-in button on `xSmall` devices.

<!-- How were these changes implemented? -->

**How**: The addition of an `xSmall` breakpoint constant and supporting logic within `DeviceSizeProvider`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
