### PR TITLE
feat(Breadcrumb) Truncate final Breadcrumb.Item

### DIFF
--- a/catalog/pages/breadcrumbs/index.md
+++ b/catalog/pages/breadcrumbs/index.md
@@ -48,7 +48,19 @@ rows:
 
 ```react
 <Breadcrumb style={breadcrumbStyles}>
-    <Breadcrumb.Item position="1" href="/" style={breadcrumbStyles}>Home</Breadcrumb.Item>
-    <Breadcrumb.Item position="2" style={breadcrumbStyles}>Breadcrumbs</Breadcrumb.Item>
+    <Breadcrumb.Item position="1" role="link" ariaLabel="Home" href="/" style={breadcrumbStyles}>Home</Breadcrumb.Item>
+    <Breadcrumb.Item position="2" ariaLabel="Breadcrumbs" style={breadcrumbStyles}>Breadcrumbs</Breadcrumb.Item>
+</Breadcrumb>
+```
+
+### Breadcrumb with Truncated Breadcrumb.Items
+
+```react
+<Breadcrumb style={breadcrumbStyles}>
+    <Breadcrumb.Item position="1" ariaLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit" style={breadcrumbStyles}>Lorem ipsum dolor sit amet, consectetur adipiscing elit</Breadcrumb.Item>
+    <Breadcrumb.Item position="2" ariaLabel="Pellentesque ornare nibh sed urna tincidunt, non bibendum enim porttitor." style={breadcrumbStyles}>Pellentesque ornare nibh sed urna tincidunt, non bibendum enim porttitor.
+</Breadcrumb.Item>
+    <Breadcrumb.Item position="3" ariaLabel="Cras vulputate nibh in lectus mollis, vel posuere est tincidunt." style={breadcrumbStyles}>Cras vulputate nibh in lectus mollis, vel posuere est tincidunt.
+</Breadcrumb.Item>
 </Breadcrumb>
 ```

--- a/src/components/Breadcrumbs/Breadcrumb.js
+++ b/src/components/Breadcrumbs/Breadcrumb.js
@@ -8,6 +8,7 @@ const Breadcrumb = ({ children, ...props }) => (
     <StyledBreadcrumb
       itemScope
       itemType="http://schema.org/Breadcrumb"
+      childrenLen={children && Array.from(children).length}
       {...props}
     >
       {children}

--- a/src/components/Breadcrumbs/Breadcrumb.styles.js
+++ b/src/components/Breadcrumbs/Breadcrumb.styles.js
@@ -15,7 +15,6 @@ const StyledBreadcrumb = ListUnstyled.extend`
 
   li:last-of-type {
     min-width: 0;
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/components/Breadcrumbs/Breadcrumb.styles.js
+++ b/src/components/Breadcrumbs/Breadcrumb.styles.js
@@ -6,8 +6,19 @@ const StyledBreadcrumb = ListUnstyled.extend`
   font-weight: ${typography.weight.semiBold};
   display: flex;
   flex-flow: row;
-  align-items: center;
-  color: ${props => props.color || "inherit"};
+  color: ${({ color }) => color || "inherit"};
+  ${({ childrenLen }) =>
+    childrenLen &&
+    `
+    flex: 0 1 ${Math.floor(100 / childrenLen)}%;
+  `} align-items: center;
+
+  li:last-of-type {
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   li:not(:last-of-type):after {
     padding: 0 ${spacing.slim};

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -1,27 +1,35 @@
 import React from "react";
 import PropTypes from "prop-types";
-
+import styled from "styled-components";
 import typography from "../../theme/typography";
 import { Link, StyledText } from "../Text";
 
+const InlineLi = styled.li`
+  white-space: nowrap;
+`;
+
 const Text = StyledText.withComponent("span");
 
-const BreadcrumbItem = ({ position, children, ...props }) => {
-  const { href } = props;
+const BreadcrumbItem = ({ position, children, href, ...props }) => {
   const Tag = href ? Link : Text;
 
   return (
-    <li
+    <InlineLi
       itemProp="itemListElement"
       itemScope
       itemType="http://schema.org/ListItem"
     >
-      <Tag itemProp="item" {...props} fontSize={typography.size.uno}>
+      <Tag
+        itemProp="item"
+        fontSize={typography.size.uno}
+        href={href || null}
+        {...props}
+      >
         {children}
       </Tag>
       {children && <meta itemProp="name" content={children} />}
       {position && <meta itemProp="position" content={position} />}
-    </li>
+    </InlineLi>
   );
 };
 

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -25,7 +25,6 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
 
 .c0 li:last-of-type {
   min-width: 0;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -13,11 +13,21 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  color: inherit;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  color: inherit;
+}
+
+.c0 li:last-of-type {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c0 li:not(:last-of-type):after {

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] = `
-.c0 {
+.c1 {
   font-size: 12px;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -13,13 +13,18 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
   text-decoration: none;
 }
 
+.c0 {
+  white-space: nowrap;
+}
+
 <li
+  className="c0"
   itemProp="itemListElement"
   itemScope={true}
   itemType="http://schema.org/ListItem"
 >
   <a
-    className="c0"
+    className="c1"
     color=""
     fontSize="12px"
     href="/"
@@ -42,6 +47,10 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
 
 exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] = `
 .c0 {
+  white-space: nowrap;
+}
+
+.c1 {
   font-size: 12px;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -51,14 +60,15 @@ exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] =
 }
 
 <li
+  className="c0"
   itemProp="itemListElement"
   itemScope={true}
   itemType="http://schema.org/ListItem"
 >
   <span
-    className="c0"
+    className="c1"
     fontSize="12px"
-    href=""
+    href={null}
     itemProp="item"
   >
     Home


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Truncate final breadcrumb item with ellipsis.

<!-- Why are these changes necessary? -->

**Why**: To ensure the very long breadcrumb items do not disrupt adjacent elements.

<!-- How were these changes implemented? -->

**How**: Modifications to Breadcrumb/Breadcrumb Item styling.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
