### PR TITLE
Fix(Breadcrumb) Add overflow: hidden to nav

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumb.js
+++ b/src/components/Breadcrumbs/Breadcrumb.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import StyledBreadcrumb from "./Breadcrumb.styles";
 
 const Breadcrumb = ({ children, ...props }) => (
-  <nav>
+  <nav style={{ overflow: "hidden" }}>
     <StyledBreadcrumb
       itemScope
       itemType="http://schema.org/Breadcrumb"

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -1,12 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import typography from "../../theme/typography";
 import { Link, StyledText } from "../Text";
-
-const InlineLi = styled.li`
-  white-space: nowrap;
-`;
 
 const Text = StyledText.withComponent("span");
 
@@ -14,10 +9,11 @@ const BreadcrumbItem = ({ position, children, href, ...props }) => {
   const Tag = href ? Link : Text;
 
   return (
-    <InlineLi
+    <li
       itemProp="itemListElement"
       itemScope
       itemType="http://schema.org/ListItem"
+      style={{ whiteSpace: "nowrap" }}
     >
       <Tag
         itemProp="item"
@@ -29,7 +25,7 @@ const BreadcrumbItem = ({ position, children, href, ...props }) => {
       </Tag>
       {children && <meta itemProp="name" content={children} />}
       {position && <meta itemProp="position" content={position} />}
-    </InlineLi>
+    </li>
   );
 };
 

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/Breadcrumb.spec.js.snap
@@ -35,7 +35,13 @@ exports[`<Breadcrumb /> renders correctly 1`] = `
   font-size: 12px;
 }
 
-<nav>
+<nav
+  style={
+    Object {
+      "overflow": "hidden",
+    }
+  }
+>
   <ol
     className="c0"
     itemScope={true}

--- a/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/BreadcrumbItem.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] = `
-.c1 {
+.c0 {
   font-size: 12px;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -13,18 +13,18 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
   text-decoration: none;
 }
 
-.c0 {
-  white-space: nowrap;
-}
-
 <li
-  className="c0"
   itemProp="itemListElement"
   itemScope={true}
   itemType="http://schema.org/ListItem"
+  style={
+    Object {
+      "whiteSpace": "nowrap",
+    }
+  }
 >
   <a
-    className="c1"
+    className="c0"
     color=""
     fontSize="12px"
     href="/"
@@ -47,10 +47,6 @@ exports[`<Breadcrumb.Item /> renders correctly when an href prop is passed 1`] =
 
 exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] = `
 .c0 {
-  white-space: nowrap;
-}
-
-.c1 {
   font-size: 12px;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -60,13 +56,17 @@ exports[`<Breadcrumb.Item /> renders correctly when no href prop is passed 1`] =
 }
 
 <li
-  className="c0"
   itemProp="itemListElement"
   itemScope={true}
   itemType="http://schema.org/ListItem"
+  style={
+    Object {
+      "whiteSpace": "nowrap",
+    }
+  }
 >
   <span
-    className="c1"
+    className="c0"
     fontSize="12px"
     href={null}
     itemProp="item"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:  Add `overflow: "hidden"` to `Breadcrumb` `nav` element

<!-- Why are these changes necessary? -->

**Why**: Ensure truncation functions as expected in web application.

<!-- How were these changes implemented? -->

**How**: Changes to CSS.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
