### PR TITLE
feat(DataTids) Add data-tids to Button and margins styled-components via attrs

### DIFF
--- a/src/components/Button/Base.styles.js
+++ b/src/components/Button/Base.styles.js
@@ -36,7 +36,9 @@ const VARIANTS = {
   }
 };
 
-export const StyledButton = styled.button`
+export const StyledButton = styled.button.attrs({
+  "data-tid": ({ dataTid }) => dataTid
+})`
   font-size: ${typography.size.hecto};
   font-weight: ${typography.weight.semiBold};
   height: ${HEIGHT};

--- a/src/components/Button/__tests__/Badge.spec.js
+++ b/src/components/Button/__tests__/Badge.spec.js
@@ -76,4 +76,14 @@ describe("Badge />", () => {
     Simulate.click(getByText("Badge"));
     expect(onClick).toHaveBeenCalled();
   });
+
+  it("renders with a dataTid prop when passed", () => {
+    const component = renderer.create(
+      <Badge variant="standard" dataTid="badge">
+        Badge
+      </Badge>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/Button/__tests__/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Badge.spec.js.snap
@@ -44,6 +44,7 @@ exports[`Badge /> renders link Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   href="/"
 >
   Badge
@@ -94,6 +95,7 @@ exports[`Badge /> renders outline Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
 >
   Badge
 </button>
@@ -143,6 +145,7 @@ exports[`Badge /> renders outline disabled Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
 >
   Badge
@@ -193,6 +196,7 @@ exports[`Badge /> renders standard Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
 >
   Badge
 </button>
@@ -242,6 +246,7 @@ exports[`Badge /> renders standard disabled Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
 >
   Badge
@@ -292,6 +297,7 @@ exports[`Badge /> renders transparent Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
 >
   Badge
 </button>
@@ -341,7 +347,58 @@ exports[`Badge /> renders transparent disabled Badge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
+>
+  Badge
+</button>
+`;
+
+exports[`Badge /> renders with a dataTid prop when passed 1`] = `
+.c0 {
+  font-size: 14px;
+  font-weight: 600;
+  height: 36px;
+  width: 100%;
+  min-width: 100px;
+  text-align: center;
+  text-transform: capitalize;
+  border-radius: 2px;
+  cursor: pointer;
+  color: rgba(255,255,255,1);
+  background-color: rgba(2,108,223,1);
+  border: 1px solid rgba(2,108,223,1);
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row;
+  -ms-flex-flow: row;
+  flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 45px;
+  min-width: 45px;
+  height: 20px;
+}
+
+.c0:disabled {
+  color: rgba(255,255,255,1);
+  background-color: rgba(2,108,223,0.2);
+  border: 1px solid rgba(2,108,223,0.2);
+  cursor: not-allowed;
+}
+
+<button
+  className="c0"
+  data-tid="badge"
 >
   Badge
 </button>

--- a/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Base.spec.js.snap
@@ -27,6 +27,7 @@ exports[`<Button /> renders link button correctly 1`] = `
 
 <a
   className="c0"
+  data-tid={undefined}
   href="/"
   rel={undefined}
 >
@@ -59,6 +60,7 @@ exports[`<Button /> renders outline button correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
 >
   Dummy Label
 </button>
@@ -89,6 +91,7 @@ exports[`<Button /> renders outline disabled button correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
 >
   Dummy Label
@@ -120,6 +123,7 @@ exports[`<Button /> renders standard button correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
 >
   Dummy Label
 </button>
@@ -150,6 +154,7 @@ exports[`<Button /> renders standard disabled button correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
 >
   Dummy Label
@@ -181,6 +186,7 @@ exports[`<Button /> renders transparent button correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
 >
   Dummy Label
 </button>
@@ -211,6 +217,7 @@ exports[`<Button /> renders transparent disabled button correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
 >
   Dummy Label

--- a/src/components/Button/__tests__/__snapshots__/RatingBadge.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/RatingBadge.spec.js.snap
@@ -55,6 +55,7 @@ exports[`RatingBadge /> renders link RatingBadge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   href="/"
   itemProp="aggregateRating"
   itemScope={true}
@@ -147,6 +148,7 @@ exports[`RatingBadge /> renders outline RatingBadge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   itemProp="aggregateRating"
   itemScope={true}
   itemType="https://schema.org/AggregateRating"
@@ -238,6 +240,7 @@ exports[`RatingBadge /> renders outline disabled RatingBadge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
   itemProp="aggregateRating"
   itemScope={true}
@@ -330,6 +333,7 @@ exports[`RatingBadge /> renders standard RatingBadge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   itemProp="aggregateRating"
   itemScope={true}
   itemType="https://schema.org/AggregateRating"
@@ -421,6 +425,7 @@ exports[`RatingBadge /> renders standard disabled RatingBadge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
   itemProp="aggregateRating"
   itemScope={true}
@@ -513,6 +518,7 @@ exports[`RatingBadge /> renders transparent RatingBadge correctly 1`] = `
 
 <button
   className="c0"
+  data-tid={undefined}
   itemProp="aggregateRating"
   itemScope={true}
   itemType="https://schema.org/AggregateRating"
@@ -604,6 +610,7 @@ exports[`RatingBadge /> renders transparent disabled RatingBadge correctly 1`] =
 
 <button
   className="c0"
+  data-tid={undefined}
   disabled={true}
   itemProp="aggregateRating"
   itemScope={true}

--- a/src/components/Header/Heading.js
+++ b/src/components/Header/Heading.js
@@ -14,7 +14,9 @@ const Strong = Span.extend`
   font-weight: ${typography.weight.extraBold};
 `;
 
-const margins = styled.span`
+const margins = styled.span.attrs({
+  "data-tid": ({ dataTid }) => dataTid
+})`
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: ${spacing.cozy};

--- a/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/index.spec.js.snap
@@ -1,5 +1,182 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Header renders with a dataTid prop when passed 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.c2 .row {
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c0 {
+  z-index: 1;
+  background-image: linear-gradient(76deg,#026cdf,#3ac7ff);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-height: 122px;
+}
+
+.c0.gradient--overlay:after {
+  z-index: 2;
+  height: 100%;
+  content: "";
+  opacity: 0.4;
+  top: 0;
+  left: 0;
+  right: 0;
+  position: absolute;
+  background-image: linear-gradient(77deg,rgba(0,0,0,0),#000000);
+}
+
+.c1 {
+  margin: 0 auto;
+  max-width: 1248px;
+  width: 100%;
+  padding-left: 16px;
+  padding-right: 16px;
+  box-sizing: border-box;
+  padding-top: 60px;
+}
+
+.c5 {
+  font-weight: 300;
+}
+
+.c4 {
+  font-weight: 300;
+  font-weight: 800;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-bottom: 8px;
+  line-height: 1.25;
+  color: rgba(255,255,255,1);
+  font-size: 24px;
+}
+
+@media screen and (min-width:481px) {
+  .c2 {
+    margin-left: -12px;
+    margin-right: -12px;
+  }
+}
+
+@media screen and (min-width:481px) {
+  .c0 {
+    background-image: linear-gradient(80deg,#026cdf,#3ac7ff);
+  }
+}
+
+@media screen and (min-width:769px) {
+  .c0 {
+    background-image: linear-gradient(81deg,#026cdf,#3ac7ff);
+  }
+}
+
+@media screen and (min-width:481px) {
+  .c0.gradient--overlay:after {
+    background-image: linear-gradient(82deg,rgba(0,0,0,0),#000000);
+  }
+}
+
+@media screen and (min-width:769px) {
+  .c0.gradient--overlay:after {
+    background-image: linear-gradient(86deg,rgba(0,0,0,0),#000000);
+  }
+}
+
+@media screen and (min-width:481px) {
+  .c0 {
+    min-height: 140px;
+  }
+}
+
+@media screen and (min-width:769px) {
+  .c0 {
+    min-height: 218px;
+  }
+}
+
+@media screen and (min-width:481px) {
+  .c1 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media screen and (min-width:481px) {
+  .c3 {
+    font-size: 32px;
+  }
+}
+
+@media screen and (min-width:769px) {
+  .c3 {
+    font-size: 46px;
+  }
+}
+
+<header
+  className="c0"
+  from="#026cdf"
+  style={Object {}}
+  to="#3ac7ff"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="row c2"
+    >
+      <h2
+        className="c3"
+        data-tid="genericHeader"
+      >
+        <span
+          className="c4"
+        >
+          Generic
+        </span>
+         
+        <span
+          className="c5"
+        >
+          Header
+        </span>
+      </h2>
+    </div>
+  </div>
+</header>
+`;
+
 exports[`Header renders with custom level 1`] = `
 .c2 {
   display: -webkit-box;
@@ -159,6 +336,7 @@ exports[`Header renders with custom level 1`] = `
       <h1
         className="c3"
         color="blue"
+        data-tid={undefined}
       >
         <span
           className="c4"
@@ -335,6 +513,7 @@ exports[`Header renders with default 1`] = `
     >
       <h2
         className="c3"
+        data-tid={undefined}
       >
         <span
           className="c4"

--- a/src/components/Header/__tests__/index.spec.js
+++ b/src/components/Header/__tests__/index.spec.js
@@ -30,4 +30,17 @@ describe("Header", () => {
 
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it("renders with a dataTid prop when passed", () => {
+    const component = renderer.create(
+      <Header>
+        <Heading dataTid="genericHeader">
+          <Heading.Strong>Generic</Heading.Strong>{" "}
+          <Heading.Span>Header</Heading.Span>
+        </Heading>
+      </Header>
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -753,6 +753,7 @@ exports[`<ListRow /> renders eventListRow with container 1`] = `
         <span
           aria-label="See Tickets"
           className="c19"
+          data-tid={undefined}
           role="button"
           width="102px"
         >
@@ -1555,6 +1556,7 @@ exports[`<ListRow /> renders eventListRow with link correctly 1`] = `
       <span
         aria-label="See Tickets"
         className="c18"
+        data-tid={undefined}
         role="button"
         width="102px"
       >
@@ -2256,6 +2258,7 @@ exports[`<ListRow /> renders standard eventListRow correctly 1`] = `
       <span
         aria-label="See Tickets"
         className="c18"
+        data-tid={undefined}
         role="button"
         width="102px"
       >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Enable addition of `data-tids` to `Button` and `margins` `styled-components`

<!-- Why are these changes necessary? -->

**Why**: Automation testing

<!-- How were these changes implemented? -->

**How**: Via `styled.attrs` method

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
