### PR TITLE
refactor(ImageCard): Use explicit title and subTitle props to render caption with overlay, rather than using first two children

### DIFF
--- a/catalog/pages/image_card/index.js
+++ b/catalog/pages/image_card/index.js
@@ -6,9 +6,28 @@ import Column from "../../../src/components/Grid/Column";
 import Container from "../../../src/components/Grid/Container";
 import spacing from "../../../src/theme/spacing";
 
+const additionalContentStyles = {
+  backgroundColor: "white",
+  padding: "10px 0",
+  textAlign: "center"
+};
+
+const additionalContentTransparentStyles = {
+  ...additionalContentStyles,
+  backgroundColor: "transparent"
+};
+
 export default {
   path: "/image_card",
   title: "Image Card",
-  imports: { ImageCard, Row, Container, Column, spacing },
+  imports: {
+    ImageCard,
+    Row,
+    Container,
+    Column,
+    spacing,
+    additionalContentStyles,
+    additionalContentTransparentStyles
+  },
   content: pageLoader(() => import("./index.md"))
 };

--- a/catalog/pages/image_card/index.md
+++ b/catalog/pages/image_card/index.md
@@ -19,11 +19,18 @@ rows:
     Type: string
     Default:
     Notes: Alt text for image
-  - Prop: children
-    Type: ImageCard.Title, ImageCard.SubTitle, ReactElement
+  - Prop: title
+    Type: string
     Default:
-    Notes: In order the first two children are wrapped in a caption,
-           the remaining elements are added as additional content under the image
+    Notes: Caption title
+  - Prop: subTitle
+    Type: string
+    Default:
+    Notes: Caption subTitle
+  - Prop: children
+    Type: Node (e.g. ImageCard.Title, ImageCard.SubTitle, ReactElement, string, null)
+    Default:
+    Notes: Rendered as content under the image
 ```
 
 ```react
@@ -34,31 +41,37 @@ const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center
     <Container style={{ paddingBottom: "20px", paddingTop: "20px" }}>
         <Row>
             <Column medium={4} style={{marginTop: spacing.gutters.small}}>
-                <ImageCard src="https://placekitten.com/g/512/288">
-                    <ImageCard.Title>Title</ImageCard.Title>
-                    <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                </ImageCard>
+                <ImageCard
+                    src="https://placekitten.com/g/512/288"
+                    title={<ImageCard.Title>Title</ImageCard.Title>}
+                    subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                />
             </Column>
             <Column small={6} medium={4} style={{marginTop: spacing.gutters.small}}>
                 <ImageCard src="https://placekitten.com/g/512/288" />
             </Column>
             <Column small={6} medium={4} style={{marginTop: spacing.gutters.small}}>
-                <ImageCard src="https://placekitten.com/g/512/288">
-                    <ImageCard.Title>Title</ImageCard.Title>
-                    <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                </ImageCard>
+                <ImageCard
+                    src="https://placekitten.com/g/512/288"
+                    title={<ImageCard.Title>Title</ImageCard.Title>}
+                    subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                />
             </Column>
             <Column medium={6} style={{marginTop: spacing.gutters.small}}>
-                <ImageCard src="https://placekitten.com/g/512/288">
-                    <ImageCard.Title>Title</ImageCard.Title>
-                    <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+                <ImageCard
+                    src="https://placekitten.com/g/512/288"
+                    title={<ImageCard.Title>Title</ImageCard.Title>}
+                    subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                >
                     <div style={styles}>Additional Content</div>
                 </ImageCard>
             </Column>
             <Column medium={6} style={{marginTop: spacing.gutters.small}}>
-                <ImageCard src="https://placekitten.com/g/512/288">
-                    <ImageCard.Title>Title</ImageCard.Title>
-                    <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+                <ImageCard
+                    src="https://placekitten.com/g/512/288"
+                    title={<ImageCard.Title>Title</ImageCard.Title>}
+                    subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                >
                     <div style={styles}>Additional Content</div>
                 </ImageCard>
             </Column>
@@ -79,16 +92,20 @@ const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center
     <Container style={{ paddingBottom: "20px", paddingTop: "20px" }}>
         <Row>
             <Column medium={6} large={3} style={{marginTop: spacing.gutters.small}}>
-                <ImageCard type="half" src="https://placekitten.com/g/512/288">
-                    <ImageCard.Title>Title</ImageCard.Title>
-                    <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                </ImageCard>
+                <ImageCard
+                    type="half"
+                    src="https://placekitten.com/g/512/288"
+                    title={<ImageCard.Title>Title</ImageCard.Title>}
+                    subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                />
             </Column>
             <Column medium={6} large={3} style={{marginTop: spacing.gutters.small}}>
-                <ImageCard type="half" src="https://placekitten.com/g/512/288">
-                    <ImageCard.Title>Title</ImageCard.Title>
-                    <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-                </ImageCard>
+                <ImageCard
+                    type="half"
+                    src="https://placekitten.com/g/512/288"
+                    title={<ImageCard.Title>Title</ImageCard.Title>}
+                    subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                />
             </Column>
         </Row>
     </Container>

--- a/catalog/pages/image_card/index.md
+++ b/catalog/pages/image_card/index.md
@@ -20,15 +20,19 @@ rows:
     Default:
     Notes: Alt text for image
   - Prop: title
-    Type: string
+    Type: Node (e.g. ImageCard.Title, ImageCard.SubTitle, ReactElement, string, null)
     Default:
     Notes: Caption title
   - Prop: subTitle
-    Type: string
+    Type: Node (e.g. ImageCard.Title, ImageCard.SubTitle, ReactElement, string, null)
     Default:
     Notes: Caption subTitle
+  - Prop: variant
+    Type: string
+    Default: standard
+    Notes: Determines style variant (one of "standard"; "transparent")
   - Prop: children
-    Type: Node (e.g. ImageCard.Title, ImageCard.SubTitle, ReactElement, string, null)
+    Type: Node (e.g. ReactElement, string, null)
     Default:
     Notes: Rendered as content under the image
 ```
@@ -36,7 +40,6 @@ rows:
 ```react
 responsive: true
 ---
-const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center" };
 <div>
     <Container style={{ paddingBottom: "20px", paddingTop: "20px" }}>
         <Row>
@@ -55,6 +58,7 @@ const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center
                     src="https://placekitten.com/g/512/288"
                     title={<ImageCard.Title>Title</ImageCard.Title>}
                     subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    variant="transparent"
                 />
             </Column>
             <Column medium={6} style={{marginTop: spacing.gutters.small}}>
@@ -63,7 +67,7 @@ const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center
                     title={<ImageCard.Title>Title</ImageCard.Title>}
                     subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
                 >
-                    <div style={styles}>Additional Content</div>
+                    <div style={additionalContentStyles}>Additional Content</div>
                 </ImageCard>
             </Column>
             <Column medium={6} style={{marginTop: spacing.gutters.small}}>
@@ -71,8 +75,9 @@ const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center
                     src="https://placekitten.com/g/512/288"
                     title={<ImageCard.Title>Title</ImageCard.Title>}
                     subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    variant="transparent"
                 >
-                    <div style={styles}>Additional Content</div>
+                    <div style={additionalContentTransparentStyles}>Additional Content</div>
                 </ImageCard>
             </Column>
         </Row>
@@ -87,7 +92,6 @@ Displays an image card in "half" mode. This mode does not support additional con
 ```react
 responsive: true
 ---
-const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center" };
 <div>
     <Container style={{ paddingBottom: "20px", paddingTop: "20px" }}>
         <Row>
@@ -105,6 +109,7 @@ const styles = { backgroundColor: "white", padding: "10px 0", textAlign: "center
                     src="https://placekitten.com/g/512/288"
                     title={<ImageCard.Title>Title</ImageCard.Title>}
                     subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+                    variant="transparent"
                 />
             </Column>
         </Row>

--- a/src/components/Card/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Card/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card renders standard card 1`] = `
+.c0 {
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  background-color: rgba(255,255,255,1);
+  box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
+}
+
+<div
+  className="card card--standard c0"
+/>
+`;
+
+exports[`Card renders transparent card 1`] = `
+.c0 {
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  background-color: transparent;
+}
+
+<div
+  className="card card--transparent c0"
+/>
+`;

--- a/src/components/Card/__tests__/index.spec.js
+++ b/src/components/Card/__tests__/index.spec.js
@@ -1,0 +1,18 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import Card from "../index";
+
+describe("Card", () => {
+  it("renders standard card", () => {
+    const component = renderer.create(<Card />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it("renders transparent card", () => {
+    const component = renderer.create(<Card variant="transparent" />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,12 +1,43 @@
 import styled from "styled-components";
+import PropTypes from "prop-types";
+import classnames from "classnames";
 
 import colors from "../../theme/colors";
 import constants from "../../theme/constants";
 
-export default styled.div`
+const VARIANTS = {
+  standard: {
+    backgroundColor: colors.white.base
+  },
+  transparent: {
+    backgroundColor: "transparent"
+  }
+};
+
+const Card = styled.div.attrs({
+  className: ({ variant }) =>
+    classnames({
+      card: true,
+      [`card--${variant}`]: !!variant
+    })
+})`
   position: relative;
   overflow: hidden;
   border-radius: ${constants.borderRadius.large};
-  background-color: ${colors.white.base};
-  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
+  background-color: ${({ variant }) => VARIANTS[variant].backgroundColor};
+  ${({ variant }) =>
+    variant !== "transparent" &&
+    `
+    box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
+  ;`};
 `;
+
+Card.propTypes = {
+  variant: PropTypes.string
+};
+
+Card.defaultProps = {
+  variant: "standard"
+};
+
+export default Card;

--- a/src/components/ImageCard/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/ImageCard/__tests__/__snapshots__/index.spec.js.snap
@@ -6,7 +6,7 @@ exports[`ImageCard renders standard card 1`] = `
   overflow: hidden;
   border-radius: 4px;
   background-color: rgba(255,255,255,1);
-  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.08),0 0 4px 0 rgba(0,0,0,0.16);
+  box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
 }
 
 .c2 {
@@ -26,14 +26,54 @@ exports[`ImageCard renders standard card 1`] = `
 }
 
 <div
-  className="c0"
+  className="card card--standard c0"
 >
   <div
-    className="c1"
+    className="image-card--container c1"
   >
     <img
       alt=""
-      className="c2"
+      className="image-card__image c2"
+      src="http://localhost/img.png"
+    />
+    
+  </div>
+</div>
+`;
+
+exports[`ImageCard renders transparent card 1`] = `
+.c0 {
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  background-color: transparent;
+}
+
+.c2 {
+  width: 100%;
+  max-width: 100%;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+}
+
+<div
+  className="card card--transparent c0"
+>
+  <div
+    className="image-card--container c1"
+  >
+    <img
+      alt=""
+      className="image-card__image c2"
       src="http://localhost/img.png"
     />
     
@@ -47,7 +87,7 @@ exports[`ImageCard renders type = half 1`] = `
   overflow: hidden;
   border-radius: 4px;
   background-color: rgba(255,255,255,1);
-  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.08),0 0 4px 0 rgba(0,0,0,0.16);
+  box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
 }
 
 .c2 {
@@ -96,27 +136,27 @@ exports[`ImageCard renders type = half 1`] = `
 }
 
 <div
-  className="c0"
+  className="image-card--container c0"
 >
   <div
-    className="c1"
+    className="card card--standard c1"
   >
     <img
       alt=""
-      className="c2"
+      className="image-card__image c2"
       src="http://localhost/img.png"
     />
   </div>
   <div
-    className="c3"
+    className="image-card__caption-container c3"
   >
     <span
-      className="c4"
+      className="image-card__title c4"
     >
       Title
     </span>
     <span
-      className="c5"
+      className="image-card__subtitle c5"
     >
       Sub Title
     </span>
@@ -130,7 +170,7 @@ exports[`ImageCard renders with custom image 1`] = `
   overflow: hidden;
   border-radius: 4px;
   background-color: rgba(255,255,255,1);
-  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.08),0 0 4px 0 rgba(0,0,0,0.16);
+  box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
 }
 
 .c2 {
@@ -183,25 +223,25 @@ exports[`ImageCard renders with custom image 1`] = `
 }
 
 <div
-  className="c0"
+  className="card card--standard c0"
 >
   <div
-    className="c1"
+    className="image-card--container c1"
   >
     <svg />
     <div
-      className="c2"
+      className="image-card__overlay c2"
     >
       <div
-        className="c3"
+        className="image-card__caption-container c3"
       >
         <span
-          className="c4"
+          className="image-card__title c4"
         >
           Title
         </span>
         <span
-          className="c5"
+          className="image-card__subtitle c5"
         >
           Sub Title
         </span>
@@ -220,7 +260,7 @@ exports[`ImageCard renders with title & subtitle 1`] = `
   overflow: hidden;
   border-radius: 4px;
   background-color: rgba(255,255,255,1);
-  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.08),0 0 4px 0 rgba(0,0,0,0.16);
+  box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
 }
 
 .c2 {
@@ -278,29 +318,29 @@ exports[`ImageCard renders with title & subtitle 1`] = `
 }
 
 <div
-  className="c0"
+  className="card card--standard c0"
 >
   <div
-    className="c1"
+    className="image-card--container c1"
   >
     <img
       alt=""
-      className="c2"
+      className="image-card__image c2"
       src="http://localhost/img.png"
     />
     <div
-      className="c3"
+      className="image-card__overlay c3"
     >
       <div
-        className="c4"
+        className="image-card__caption-container c4"
       >
         <span
-          className="c5"
+          className="image-card__title c5"
         >
           Title
         </span>
         <span
-          className="c6"
+          className="image-card__subtitle c6"
         >
           Sub Title
         </span>
@@ -316,7 +356,7 @@ exports[`ImageCard renders with title & subtitle, extra content 1`] = `
   overflow: hidden;
   border-radius: 4px;
   background-color: rgba(255,255,255,1);
-  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.08),0 0 4px 0 rgba(0,0,0,0.16);
+  box-shadow: '0 4px 4px 0 rgba(0, 0, 0, 0.08), 0 0 4px 0 rgba(0, 0, 0, 0.16);
 }
 
 .c2 {
@@ -374,29 +414,29 @@ exports[`ImageCard renders with title & subtitle, extra content 1`] = `
 }
 
 <div
-  className="c0"
+  className="card card--standard c0"
 >
   <div
-    className="c1"
+    className="image-card--container c1"
   >
     <img
       alt=""
-      className="c2"
+      className="image-card__image c2"
       src="http://localhost/img.png"
     />
     <div
-      className="c3"
+      className="image-card__overlay c3"
     >
       <div
-        className="c4"
+        className="image-card__caption-container c4"
       >
         <span
-          className="c5"
+          className="image-card__title c5"
         >
           Title
         </span>
         <span
-          className="c6"
+          className="image-card__subtitle c6"
         >
           Sub Title
         </span>

--- a/src/components/ImageCard/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/ImageCard/__tests__/__snapshots__/index.spec.js.snap
@@ -1,64 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ImageCard renders card without overlay 1`] = `
-.c0 {
-  position: relative;
-  overflow: hidden;
-  border-radius: 4px;
-  background-color: rgba(255,255,255,1);
-  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.08),0 0 4px 0 rgba(0,0,0,0.16);
-}
-
-.c2 {
-  width: 100%;
-  max-width: 100%;
-}
-
-.c3 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  position: relative;
-}
-
-<div
-  className="c0"
->
-  <div
-    className="c1"
-  >
-    <img
-      alt=""
-      className="c2"
-      src="http://localhost/img.png"
-    />
-    <div
-      className="c3"
-    />
-  </div>
-</div>
-`;
-
 exports[`ImageCard renders standard card 1`] = `
 .c0 {
   position: relative;
@@ -73,22 +14,6 @@ exports[`ImageCard renders standard card 1`] = `
   max-width: 100%;
 }
 
-.c3 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -111,9 +36,7 @@ exports[`ImageCard renders standard card 1`] = `
       className="c2"
       src="http://localhost/img.png"
     />
-    <div
-      className="c3"
-    />
+    
   </div>
 </div>
 `;
@@ -286,9 +209,7 @@ exports[`ImageCard renders with custom image 1`] = `
     </div>
   </div>
   <div>
-    <div>
-      Extra content
-    </div>
+    Extra content
   </div>
 </div>
 `;
@@ -483,9 +404,7 @@ exports[`ImageCard renders with title & subtitle, extra content 1`] = `
     </div>
   </div>
   <div>
-    <div>
-      Extra content
-    </div>
+    Extra content
   </div>
 </div>
 `;

--- a/src/components/ImageCard/__tests__/index.spec.js
+++ b/src/components/ImageCard/__tests__/index.spec.js
@@ -12,6 +12,14 @@ describe("ImageCard", () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  it("renders transparent card", () => {
+    const component = renderer.create(
+      <ImageCard variant="transparent" src="http://localhost/img.png" />
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
   it("renders with title & subtitle", () => {
     const component = renderer.create(
       <ImageCard

--- a/src/components/ImageCard/__tests__/index.spec.js
+++ b/src/components/ImageCard/__tests__/index.spec.js
@@ -11,20 +11,14 @@ describe("ImageCard", () => {
 
     expect(component.toJSON()).toMatchSnapshot();
   });
-  it("renders card without overlay", () => {
-    const component = renderer.create(
-      <ImageCard src="http://localhost/img.png" withOverlay={false} />
-    );
-
-    expect(component.toJSON()).toMatchSnapshot();
-  });
 
   it("renders with title & subtitle", () => {
     const component = renderer.create(
-      <ImageCard src="http://localhost/img.png">
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-      </ImageCard>
+      <ImageCard
+        src="http://localhost/img.png"
+        title={<ImageCard.Title>Title</ImageCard.Title>}
+        subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+      />
     );
 
     expect(component.toJSON()).toMatchSnapshot();
@@ -32,9 +26,11 @@ describe("ImageCard", () => {
 
   it("renders with title & subtitle, extra content", () => {
     const component = renderer.create(
-      <ImageCard src="http://localhost/img.png">
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+      <ImageCard
+        src="http://localhost/img.png"
+        title={<ImageCard.Title>Title</ImageCard.Title>}
+        subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+      >
         <div>Extra content</div>
       </ImageCard>
     );
@@ -45,9 +41,11 @@ describe("ImageCard", () => {
   it("renders with custom image", () => {
     const image = <svg />;
     const component = renderer.create(
-      <ImageCard image={image}>
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
+      <ImageCard
+        image={image}
+        title={<ImageCard.Title>Title</ImageCard.Title>}
+        subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+      >
         <div>Extra content</div>
       </ImageCard>
     );
@@ -56,10 +54,12 @@ describe("ImageCard", () => {
 
   it("renders type = half", () => {
     const component = renderer.create(
-      <ImageCard type="half" src="http://localhost/img.png">
-        <ImageCard.Title>Title</ImageCard.Title>
-        <ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>
-      </ImageCard>
+      <ImageCard
+        type="half"
+        src="http://localhost/img.png"
+        title={<ImageCard.Title>Title</ImageCard.Title>}
+        subTitle={<ImageCard.SubTitle>Sub Title</ImageCard.SubTitle>}
+      />
     );
 
     expect(component.toJSON()).toMatchSnapshot();

--- a/src/components/ImageCard/index.js
+++ b/src/components/ImageCard/index.js
@@ -1,4 +1,4 @@
-import React, { Children } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
@@ -57,17 +57,19 @@ const RowContainer = Container.extend`
   align-items: center;
 `;
 
-const ImageCard = ({ src, alt, children, type, ...props }) => {
-  const [title, subTitle, ...rest] = Children.toArray(children || []);
+const ImageCard = ({ src, alt, title, subTitle, children, type, ...props }) => {
   const img = props.image || <Image src={src} alt={alt} />;
   if (type === "half") {
     return (
       <RowContainer>
         <Card>{img}</Card>
-        <CaptionContainer>
-          {title}
-          {subTitle}
-        </CaptionContainer>
+        {(title || subTitle) && (
+          <CaptionContainer>
+            {title}
+            {subTitle}
+          </CaptionContainer>
+        )}
+        {children}
       </RowContainer>
     );
   }
@@ -76,16 +78,16 @@ const ImageCard = ({ src, alt, children, type, ...props }) => {
     <Card>
       <Container>
         {img}
-        <Overlay>
-          {(title || subTitle) && (
+        {(title || subTitle) && (
+          <Overlay>
             <CaptionContainer>
               {title}
               {subTitle}
             </CaptionContainer>
-          )}
-        </Overlay>
+          </Overlay>
+        )}
       </Container>
-      {(rest && rest.length && <div>{rest}</div>) || null}
+      {children}
     </Card>
   );
 };
@@ -94,6 +96,8 @@ ImageCard.propTypes = {
   type: PropTypes.oneOf(["full", "half"]),
   src: PropTypes.string,
   alt: PropTypes.string,
+  title: PropTypes.string,
+  subTitle: PropTypes.string,
   children: PropTypes.node,
   image: PropTypes.element
 };
@@ -102,6 +106,8 @@ ImageCard.defaultProps = {
   type: "full",
   alt: "",
   src: "",
+  title: "",
+  subTitle: "",
   children: null,
   image: null
 };

--- a/src/components/ImageCard/index.js
+++ b/src/components/ImageCard/index.js
@@ -8,13 +8,17 @@ import spacing from "../../theme/spacing";
 import constants from "../../theme/constants";
 import typography from "../../theme/typography";
 
-const Image = styled.img`
+const Image = styled.img.attrs({
+  className: "image-card__image"
+})`
   width: 100%;
   max-width: 100%;
 `;
 
 //  come back
-const Overlay = styled.div`
+const Overlay = styled.div.attrs({
+  className: "image-card__overlay"
+})`
   position: absolute;
   top: 0;
   left: 0;
@@ -24,7 +28,9 @@ const Overlay = styled.div`
   align-items: flex-end;
 `;
 
-const CaptionContainer = styled.div`
+const CaptionContainer = styled.div.attrs({
+  className: "image-card__caption-container"
+})`
   position: relative;
   color: ${colors.white.base};
   background-color: rgba(31, 38, 45, 0.8);
@@ -34,19 +40,25 @@ const CaptionContainer = styled.div`
   margin-bottom: ${spacing.cozy};
 `;
 
-const Title = styled.span`
+const Title = styled.span.attrs({
+  className: "image-card__title"
+})`
   display: block;
   width: 100%;
   font-size: ${typography.size.kilo};
   font-weight: ${typography.weight.semiBold};
 `;
 
-const SubTitle = styled.span`
+const SubTitle = styled.span.attrs({
+  className: "image-card__subtitle"
+})`
   font-size: ${typography.size.hecto};
   font-weight: ${typography.weight.regular};
 `;
 
-const Container = styled.div`
+const Container = styled.div.attrs({
+  className: "image-card--container"
+})`
   display: flex;
   flex-direction: column;
   position: relative;
@@ -57,12 +69,21 @@ const RowContainer = Container.extend`
   align-items: center;
 `;
 
-const ImageCard = ({ src, alt, title, subTitle, children, type, ...props }) => {
+const ImageCard = ({
+  src,
+  alt,
+  title,
+  subTitle,
+  children,
+  type,
+  variant,
+  ...props
+}) => {
   const img = props.image || <Image src={src} alt={alt} />;
   if (type === "half") {
     return (
       <RowContainer>
-        <Card>{img}</Card>
+        <Card variant={variant}>{img}</Card>
         {(title || subTitle) && (
           <CaptionContainer>
             {title}
@@ -75,7 +96,7 @@ const ImageCard = ({ src, alt, title, subTitle, children, type, ...props }) => {
   }
 
   return (
-    <Card>
+    <Card variant={variant}>
       <Container>
         {img}
         {(title || subTitle) && (
@@ -96,8 +117,9 @@ ImageCard.propTypes = {
   type: PropTypes.oneOf(["full", "half"]),
   src: PropTypes.string,
   alt: PropTypes.string,
-  title: PropTypes.string,
-  subTitle: PropTypes.string,
+  title: PropTypes.node,
+  subTitle: PropTypes.node,
+  variant: PropTypes.oneOf(["standard", "transparent"]),
   children: PropTypes.node,
   image: PropTypes.element
 };
@@ -108,6 +130,7 @@ ImageCard.defaultProps = {
   src: "",
   title: "",
   subTitle: "",
+  variant: "standard",
   children: null,
   image: null
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
* Use explicit `title` and `subTitle` props to render caption with overlay, rather than using first two `children`
* Add `classNames` to `Card` and `ImageCard` `children`
* Add `default` and `transparent` variants to `Card`

<!-- Why are these changes necessary? -->

**Why**: 
* To decouple the caption with overlay from the `ImageCard`'s `children`, thereby enhancing composability
* To promote semantic markup and make it easier to discern between elements
* To make the `Card` component applicable to additional use cases

<!-- How were these changes implemented? -->

**How**:
* Changes to `ImageCard` props, catalog implementation, documentation, and tests
* Addition and testing of classNames and variants on `Card` and `ImageCard` components

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
