### PR TITLE
fix(DeviceSize): refactor fallback detection to only apply before med…

### DIFF
--- a/src/components/DeviceSize/Provider.js
+++ b/src/components/DeviceSize/Provider.js
@@ -8,13 +8,32 @@ import constants from "../../theme/constants";
 export default class DeviceSizeProvider extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
+    // https://github.com/yannickcr/eslint-plugin-react/issues/1751
+    // eslint-disable-next-line
     fallbackDetection: PropTypes.func,
     cssOnly: PropTypes.bool
   };
 
   static defaultProps = { fallbackDetection: null, cssOnly: false };
 
-  initialState = { isSmall: true }; // eslint-disable-line
+  initialState = { isInitialized: false, isSmall: true }; // eslint-disable-line
+
+  static getDerivedStateFromProps(props, state) {
+    if (!state.isInitialized && typeof props.fallbackDetection === "function") {
+      const fallbackDetectionResult = props.fallbackDetection();
+
+      if (
+        typeof fallbackDetectionResult === "object" &&
+        fallbackDetectionResult !== null
+      ) {
+        return {
+          ...fallbackDetectionResult
+        };
+      }
+    }
+
+    return null;
+  }
 
   state = this.initialState;
 
@@ -58,6 +77,7 @@ export default class DeviceSizeProvider extends React.Component {
     }
 
     this.setState(() => ({
+      isInitialized: true,
       isSmall: this.smallMedia.matches && !this.mediumMedia.matches,
       isMedium: this.mediumMedia.matches && !this.largeMedia.matches,
       isLarge: this.largeMedia.matches && !this.xLargeMedia.matches,
@@ -74,12 +94,6 @@ export default class DeviceSizeProvider extends React.Component {
   };
 
   render() {
-    const { fallbackDetection } = this.props;
-    const val = fallbackDetection ? fallbackDetection() : this.state;
-    return (
-      <Provider value={val || this.initialState}>
-        {this.props.children}
-      </Provider>
-    );
+    return <Provider value={this.state}>{this.props.children}</Provider>;
   }
 }

--- a/src/components/DeviceSize/__test__/Provider.spec.js
+++ b/src/components/DeviceSize/__test__/Provider.spec.js
@@ -76,4 +76,25 @@ describe("DeviceSize", () => {
       expect(removeListener).toHaveBeenCalled();
     });
   });
+
+  describe("getDerivedStateFromProps()", () => {
+    it("should use fallbackDetection data to populate derived state", () => {
+      const fallbackDevices = { isSmall: false, isLarge: true };
+      const fallbackDetection = jest
+        .fn()
+        .mockImplementation(() => fallbackDevices);
+
+      const derivedState = Provider.getDerivedStateFromProps(
+        {
+          fallbackDetection
+        },
+        {
+          isInitialized: false
+        }
+      );
+
+      expect(fallbackDetection).toHaveBeenCalled();
+      expect(derivedState).toEqual(fallbackDevices);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
DeviceSizeProvider's logic for fallbackDetection prop needs to change. At the moment it overrides any information in state that has been captured by matching media queries on componentDidMount(). 

<!-- Why are these changes necessary? -->

**Why**:
`fallbackDetection` prop is being used to initialize state in DeviceSizeProvider during SSR. Issue here is that when it comes to initial render on the client - the state in DeviceSizeProvider is diverged from the state used during SSR and hydration done on client side messes up DOM resulting in broken UI. 

> React expects that the rendered content is identical between the server and the client. It can patch up differences in text content, but you should treat mismatches as bugs and fix them. In development mode, React warns about mismatches during hydration. There are no guarantees that attribute differences will be patched up in case of mismatches. This is important for performance reasons because in most apps, mismatches are rare, and so validating all markup would be prohibitively expensive.
Quote from : https://reactjs.org/docs/react-dom.html#hydrate

<!-- How were these changes implemented? -->

**How**:
Updated DeviceSizeProvider to initialize state using `fallbackDetection` until match media queries are being initialized

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
