### PR TITLE
fix(Text) Add empty string as valid accent prop value to suppress propType warnings

### DIFF
--- a/src/components/Text/Base.js
+++ b/src/components/Text/Base.js
@@ -51,6 +51,7 @@ TextBase.propTypes = {
   tag: PropTypes.oneOf(["div", "span", "p"]),
   variant: PropTypes.oneOf(["accent", "dark", "light"]),
   accent: PropTypes.oneOf([
+    "",
     "aquamarine",
     "azure",
     "alert",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add empty string as valid `accent` prop value for `Text` component.

<!-- Why are these changes necessary? -->

**Why**: To suppress propType warnings for Text component when the `variant` prop does not equal `accent`.

<!-- How were these changes implemented? -->

**How**: Add empty string as valid `accent` prop value for `Text` component.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
