### PR TITLE
fix(catalog): catalog dependency is substituted with a github repo link

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "classnames": ">=2",
     "prop-types": ">=15",
     "react": ">=15",
-    "react-dom": ">=15",
     "react-addons-css-transition-group": ">=15",
+    "react-dom": ">=15",
     "styled-components": ">=2"
   },
   "devDependencies": {
@@ -74,7 +74,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "catalog": "3.5.5",
+    "catalog": "https://github.com/nyonchev/catalog",
     "classnames": "^2.2.5",
     "eslint": "^5.0.0",
     "eslint-config-airbnb": "^16.1.0",


### PR DESCRIPTION
**What**: Catalog dependency is substituted with a github repo. The package in this repo is a Catalog fork with fixed iframe rendering functionality.

**Why**: Catlog cannot render `responsive: true` layouts in production.

**How**: Catalog fork uses mutationObserver for detecting when style are inserted. Also, it decorates `prototype. CSSStyleSheet.insertRule` for detecting styles insertion in production.

**Checklist**:
* [ ] Documentation "N/A"
* [ ] Tests "N/A"
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->