### PR TITLE
fix(Build) Set testEnvironment and testURL in jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     ]
   },
   "jest": {
+    "testURL": "http://localhost/",
     "testEnvironment": "jsdom",
     "setupTestFrameworkScriptFile": "./config/jest.config.js",
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     ]
   },
   "jest": {
+    "testEnvironment": "jsdom",
     "setupTestFrameworkScriptFile": "./config/jest.config.js",
     "collectCoverageFrom": [
       "src/**/*.js"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Set `testEnvironment: "jsdom"` and `testURL: "http://localhost/"` in `jest` config in `package.json`

<!-- Why are these changes necessary? -->

**Why**: The build is currently failing because DOM APIs are being called in unit tests running in a Node environment without a configured `testURL`.

<!-- How were these changes implemented? -->

**How**: Set `testEnvironment: "jsdom"` and `testURL: "http://localhost/"` in `jest` config in `package.json`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
