### PR TITLE
fix(listRow): Show either Title or Subtitle on expanded listRow

### DIFF
--- a/catalog/pages/list_row/index.md
+++ b/catalog/pages/list_row/index.md
@@ -19,6 +19,9 @@ rows:
   - Prop: children
     Type: node
     Notes: Optional. Default is null.
+  - Prop: onExpandShow
+    Type:  one of either "title" or "subTitle"
+    Notes: Optional. Defualt is "subTitle"
 ```
 
 ### ListContainer

--- a/src/components/List/Container.js
+++ b/src/components/List/Container.js
@@ -13,7 +13,6 @@ import spacing from "../../theme/spacing";
 
 const Container = styled.div`
   width: 100%;
-  overflow: auto;
   padding-left: ${spacing.cozy};
   padding-right: ${spacing.cozy};
 `;

--- a/src/components/List/Row.js
+++ b/src/components/List/Row.js
@@ -27,13 +27,15 @@ const ListRow = ({ children, rowItem, index, onOverflowClick, ...props }) => (
 );
 
 ListRow.defaultProps = {
-  children: null
+  children: null,
+  onExpandShow: "subTitle"
 };
 
 ListRow.propTypes = {
   rowItem: PropTypes.shape(rowDataShape).isRequired,
   index: PropTypes.number.isRequired,
   onOverflowClick: PropTypes.func.isRequired,
+  onExpandShow: PropTypes.oneOf(["title", "subTitle"]),
   children: PropTypes.node
 };
 

--- a/src/components/List/RowContent.js
+++ b/src/components/List/RowContent.js
@@ -25,6 +25,7 @@ const RowWrapper = styled.div`
     props.isOpen
       ? "0 4px 8px 0 rgba(0, 0, 0, 0.01), 0 4px 10px 0 rgba(0, 0, 0, 0.19)"
       : 0};
+  transition: box-shadow 0.5s ease-in-out;
   `};
 
   &:not(:last-of-type) {
@@ -90,16 +91,12 @@ const DateWrapper = styled.div`
   min-width: 101px;
   max-width: 116px;
   padding-left: ${spacing.cozy};
-  ${largeAndUp`
-   padding-left: 0;
-  }
-  `};
 `;
 
 const TitleColumn = styled(Column)`
   display: none;
   ${largeAndUp`
-    display: ${props => (props.isOpen ? "none" : "flex")};
+    display: ${props => (props.hideOnExpand ? "none" : "flex")};
     justify-content: ${props => (props.isOpen ? "center" : "flex-start")};
     align-items: center;
   `};
@@ -114,7 +111,7 @@ const MobileOnlyColumn = styled(Column)`
 const SubTitleColumn = styled(Column)`
   display: none;
   ${largeAndUp`
-    display: flex;
+    display: ${props => (props.hideOnExpand ? "none" : "flex")};
     justify-content: ${props => (props.isOpen ? "center" : "flex-start")};
     align-items: center;
   `};
@@ -202,6 +199,7 @@ const ListRowContent = ({
   isOpen,
   index,
   onOverflowClick,
+  onExpandShow,
   children
 }) => (
   <RowWrapper variant={variant} isOpen={isOpen}>
@@ -235,10 +233,16 @@ const ListRowContent = ({
             <SingleLineSecondaryText>{subTitle}</SingleLineSecondaryText>
           </MobileOnlyColumn>
 
-          <TitleColumn isOpen={isOpen} large={6} xLarge={6}>
+          <TitleColumn
+            hideOnExpand={isOpen && onExpandShow === "subTitle"}
+            isOpen={isOpen}
+            large={isOpen ? 12 : 6}
+            xLarge={isOpen ? 12 : 6}
+          >
             <MultilinePrimaryText>{title}</MultilinePrimaryText>
           </TitleColumn>
           <SubTitleColumn
+            hideOnExpand={isOpen && onExpandShow === "title"}
             isOpen={isOpen}
             large={isOpen ? 12 : 6}
             xLarge={isOpen ? 12 : 6}
@@ -246,20 +250,20 @@ const ListRowContent = ({
             <MultilinePrimaryText>{subTitle}</MultilinePrimaryText>
           </SubTitleColumn>
         </Row>
-      </LinkWrapper>
 
-      <DesktopContainer>
-        <ListRowButton
-          aria-label={buttonText}
-          role="button"
-          width="102px"
-          variant="standard"
-          rowVariant={variant}
-          onClick={onClick}
-        >
-          {buttonText}
-        </ListRowButton>
-      </DesktopContainer>
+        <DesktopContainer>
+          <ListRowButton
+            aria-label={buttonText}
+            role="button"
+            width="102px"
+            variant="standard"
+            rowVariant={variant}
+            onClick={onClick}
+          >
+            {buttonText}
+          </ListRowButton>
+        </DesktopContainer>
+      </LinkWrapper>
 
       <MobileContainer>
         <IconButton
@@ -293,6 +297,7 @@ const ListRowContent = ({
 
 ListRowContent.defaultProps = {
   isOpen: false,
+  onExpandShow: "subTitle",
   children: null
 };
 
@@ -301,6 +306,7 @@ ListRowContent.propTypes = {
   isOpen: PropTypes.bool,
   index: PropTypes.number.isRequired,
   onOverflowClick: PropTypes.func.isRequired,
+  onExpandShow: PropTypes.oneOf(["title", "subTitle"]),
   children: PropTypes.node
 };
 

--- a/src/components/List/__tests__/Container.spec.js
+++ b/src/components/List/__tests__/Container.spec.js
@@ -181,7 +181,7 @@ describe("<ListContainer />", () => {
 
   it("closes the bottomSheet for the row when clicked on cross icon on mobile", () => {
     const { container, queryByTestId } = renderIntoDocument(
-      <ListContainer onRowCollapse={() => {}}>
+      <ListContainer onRowCollapse={() => {}} resizeCallBack={() => {}}>
         {listItems.map((item, index) => (
           <ListRow
             key={item.rowId}

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cross icon on mobile 1`] = `
 <div
-  class="sc-chPdSV gHWRuY"
+  class="sc-chPdSV hddFlW"
 >
   <div
-    class="sc-kEYyzF fQwHpz"
+    class="sc-kEYyzF dfTlJY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -37,7 +37,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -70,7 +70,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="sc-cvbbAY bwfHrP sc-bZQynM cfEvYQ"
+            class="sc-cvbbAY bwfHrP sc-bZQynM AkMDZ"
           >
             <div
               class="sc-gipzik hGSyBv sc-kGXeez loiItH"
@@ -88,19 +88,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -421,7 +421,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -452,7 +452,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -503,19 +503,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -836,7 +836,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -867,7 +867,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -918,19 +918,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -1256,10 +1256,10 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cross icon on mobile 2`] = `
 <div>
   <div
-    class="sc-chPdSV gHWRuY"
+    class="sc-chPdSV hddFlW"
   >
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -1291,7 +1291,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -1342,19 +1342,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -1675,7 +1675,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </div>
     </div>
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -1706,7 +1706,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -1757,19 +1757,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -2090,7 +2090,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </div>
     </div>
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -2121,7 +2121,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -2172,19 +2172,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -2510,10 +2510,10 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 
 exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cross icon on mobile 3`] = `
 <div
-  class="sc-chPdSV gHWRuY"
+  class="sc-chPdSV hddFlW"
 >
   <div
-    class="sc-kEYyzF fQwHpz"
+    class="sc-kEYyzF dfTlJY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -2545,7 +2545,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -2578,7 +2578,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
           <div
-            class="sc-cvbbAY bwfHrP sc-bZQynM cfEvYQ"
+            class="sc-cvbbAY bwfHrP sc-bZQynM AkMDZ"
           >
             <div
               class="sc-gipzik hGSyBv sc-kGXeez loiItH"
@@ -2596,19 +2596,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -2929,7 +2929,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -2960,7 +2960,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -3011,19 +3011,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -3344,7 +3344,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -3375,7 +3375,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -3426,19 +3426,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -3764,10 +3764,10 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cross icon on mobile 4`] = `
 <div>
   <div
-    class="sc-chPdSV gHWRuY"
+    class="sc-chPdSV hddFlW"
   >
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -3799,7 +3799,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -3850,19 +3850,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -4183,7 +4183,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </div>
     </div>
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -4214,7 +4214,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -4265,19 +4265,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -4598,7 +4598,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </div>
     </div>
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -4629,7 +4629,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -4680,19 +4680,19 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -5019,10 +5019,10 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
 exports[`<ListContainer /> closes the modal when clicked on an expanded item on Desktop and clicked on cross icon 1`] = `
 <div>
   <div
-    class="sc-chPdSV gHWRuY"
+    class="sc-chPdSV hddFlW"
   >
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -5053,7 +5053,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -5104,19 +5104,19 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -5269,10 +5269,10 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
 
 exports[`<ListContainer /> collapses the listRow when clicked on collapse button 1`] = `
 <div
-  class="sc-chPdSV gHWRuY"
+  class="sc-chPdSV hddFlW"
 >
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -5304,7 +5304,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -5355,19 +5355,19 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -5688,7 +5688,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -5719,7 +5719,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -5770,19 +5770,19 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -6103,7 +6103,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -6134,7 +6134,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -6185,19 +6185,19 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -6522,10 +6522,10 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
 
 exports[`<ListContainer /> expands the listRow when clicked on expand button 1`] = `
 <div
-  class="sc-chPdSV gHWRuY"
+  class="sc-chPdSV hddFlW"
 >
   <div
-    class="sc-kEYyzF fQwHpz"
+    class="sc-kEYyzF dfTlJY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -6557,7 +6557,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -6590,7 +6590,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
           <div
-            class="sc-cvbbAY bwfHrP sc-bZQynM cfEvYQ"
+            class="sc-cvbbAY bwfHrP sc-bZQynM AkMDZ"
           >
             <div
               class="sc-gipzik hGSyBv sc-kGXeez loiItH"
@@ -6608,19 +6608,19 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -6941,7 +6941,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -6972,7 +6972,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -7023,19 +7023,19 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -7356,7 +7356,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
     </div>
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -7387,7 +7387,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -7438,19 +7438,19 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -7776,10 +7776,10 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
 exports[`<ListContainer /> opens the bottomSheet for the row when clicked on overflow button 1`] = `
 <div>
   <div
-    class="sc-chPdSV gHWRuY"
+    class="sc-chPdSV hddFlW"
   >
     <div
-      class="sc-kEYyzF fQwHpz"
+      class="sc-kEYyzF dfTlJY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -7811,7 +7811,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -7844,7 +7844,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
             <div
-              class="sc-cvbbAY bwfHrP sc-bZQynM cfEvYQ"
+              class="sc-cvbbAY bwfHrP sc-bZQynM AkMDZ"
             >
               <div
                 class="sc-gipzik hGSyBv sc-kGXeez loiItH"
@@ -7862,19 +7862,19 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -8195,7 +8195,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
       </div>
     </div>
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -8226,7 +8226,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -8277,19 +8277,19 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -8610,7 +8610,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
       </div>
     </div>
     <div
-      class="sc-kEYyzF gDqNcy"
+      class="sc-kEYyzF exRIGY"
     >
       <div
         class="sc-kkGfuU iyxmsm"
@@ -8641,7 +8641,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           role="link"
         >
           <div
-            class="sc-eHgmQL guqODM"
+            class="sc-eHgmQL lcbpia"
           >
             <div
               class="sc-dxgOiQ jwaoTg"
@@ -8692,19 +8692,19 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
               </div>
             </div>
           </div>
-        </a>
-        <div
-          class="sc-iRbamj ebLCdR"
-        >
-          <span
-            aria-label="See Tickets"
-            class="sc-jAaTju knVXEA"
-            role="button"
-            width="102px"
+          <div
+            class="sc-iRbamj ebLCdR"
           >
-            See Tickets
-          </span>
-        </div>
+            <span
+              aria-label="See Tickets"
+              class="sc-jAaTju knVXEA"
+              role="button"
+              width="102px"
+            >
+              See Tickets
+            </span>
+          </div>
+        </a>
         <div
           class="sc-jlyJG kcCTet"
         >
@@ -9030,10 +9030,10 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
 
 exports[`<ListContainer /> renders ListContainer correctly without any expanded sections 1`] = `
 <div
-  class="sc-chPdSV gHWRuY"
+  class="sc-chPdSV hddFlW"
 >
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -9064,7 +9064,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -9115,19 +9115,19 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -9156,7 +9156,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
     />
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -9187,7 +9187,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -9238,19 +9238,19 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >
@@ -9279,7 +9279,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
     />
   </div>
   <div
-    class="sc-kEYyzF gDqNcy"
+    class="sc-kEYyzF exRIGY"
   >
     <div
       class="sc-kkGfuU iyxmsm"
@@ -9310,7 +9310,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         role="link"
       >
         <div
-          class="sc-eHgmQL guqODM"
+          class="sc-eHgmQL lcbpia"
         >
           <div
             class="sc-dxgOiQ jwaoTg"
@@ -9361,19 +9361,19 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
             </div>
           </div>
         </div>
-      </a>
-      <div
-        class="sc-iRbamj ebLCdR"
-      >
-        <span
-          aria-label="See Tickets"
-          class="sc-jAaTju knVXEA"
-          role="button"
-          width="102px"
+        <div
+          class="sc-iRbamj ebLCdR"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            class="sc-jAaTju knVXEA"
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         class="sc-jlyJG kcCTet"
       >

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -250,7 +250,6 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
 
 .c0 {
   width: 100%;
-  overflow: auto;
   padding-left: 8px;
   padding-right: 8px;
 }
@@ -337,6 +336,8 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
     margin-bottom: 0;
     border-radius: 4px;
     box-shadow: 0;
+    -webkit-transition: box-shadow 0.5s ease-in-out;
+    transition: box-shadow 0.5s ease-in-out;
   }
 }
 
@@ -369,12 +370,6 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
 
   .c5:hover .text--secondary:before {
     content: "";
-  }
-}
-
-@media screen and (min-width:769px) {
-  .c6 {
-    padding-left: 0;
   }
 }
 
@@ -549,20 +544,20 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
             </div>
           </div>
         </div>
-      </a>
-      <div
-        className="c18"
-      >
-        <span
-          aria-label="See Tickets"
-          className="c19"
-          onClick={[Function]}
-          role="button"
-          width="102px"
+        <div
+          className="c18"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            className="c19"
+            onClick={[Function]}
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         className="c20"
       >
@@ -875,7 +870,6 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 
 .c0 {
   width: 100%;
-  overflow: auto;
   padding-left: 8px;
   padding-right: 8px;
 }
@@ -1020,6 +1014,8 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
     margin-bottom: 0;
     border-radius: 4px;
     box-shadow: 0;
+    -webkit-transition: box-shadow 0.5s ease-in-out;
+    transition: box-shadow 0.5s ease-in-out;
   }
 }
 
@@ -1052,12 +1048,6 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
 
   .c5:hover .text--secondary:before {
     content: "";
-  }
-}
-
-@media screen and (min-width:769px) {
-  .c6 {
-    padding-left: 0;
   }
 }
 
@@ -1238,20 +1228,20 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
             </div>
           </div>
         </div>
-      </a>
-      <div
-        className="c18"
-      >
-        <span
-          aria-label="See Tickets"
-          className="c19"
-          onClick={[Function]}
-          role="button"
-          width="102px"
+        <div
+          className="c18"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            className="c19"
+            onClick={[Function]}
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         className="c20"
       >
@@ -1590,7 +1580,6 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 
 .c0 {
   width: 100%;
-  overflow: auto;
   padding-left: 8px;
   padding-right: 8px;
 }
@@ -1735,6 +1724,8 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
     margin-bottom: 0;
     border-radius: 4px;
     box-shadow: 0;
+    -webkit-transition: box-shadow 0.5s ease-in-out;
+    transition: box-shadow 0.5s ease-in-out;
   }
 }
 
@@ -1767,12 +1758,6 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
 
   .c5:hover .text--secondary:before {
     content: "";
-  }
-}
-
-@media screen and (min-width:769px) {
-  .c6 {
-    padding-left: 0;
   }
 }
 
@@ -1953,20 +1938,20 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
             </div>
           </div>
         </div>
-      </a>
-      <div
-        className="c18"
-      >
-        <span
-          aria-label="See Tickets"
-          className="c19"
-          onClick={[Function]}
-          role="button"
-          width="102px"
+        <div
+          className="c18"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            className="c19"
+            onClick={[Function]}
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         className="c20"
       >
@@ -2274,7 +2259,6 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
 
 .c0 {
   width: 100%;
-  overflow: auto;
   padding-left: 8px;
   padding-right: 8px;
 }
@@ -2361,6 +2345,8 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
     margin-bottom: 0;
     border-radius: 4px;
     box-shadow: 0;
+    -webkit-transition: box-shadow 0.5s ease-in-out;
+    transition: box-shadow 0.5s ease-in-out;
   }
 }
 
@@ -2393,12 +2379,6 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
 
   .c5:hover .text--secondary:before {
     content: "";
-  }
-}
-
-@media screen and (min-width:769px) {
-  .c6 {
-    padding-left: 0;
   }
 }
 
@@ -2573,20 +2553,20 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
             </div>
           </div>
         </div>
-      </a>
-      <div
-        className="c18"
-      >
-        <span
-          aria-label="See Tickets"
-          className="c19"
-          onClick={[Function]}
-          role="button"
-          width="102px"
+        <div
+          className="c18"
         >
-          See Tickets
-        </span>
-      </div>
+          <span
+            aria-label="See Tickets"
+            className="c19"
+            onClick={[Function]}
+            role="button"
+            width="102px"
+          >
+            See Tickets
+          </span>
+        </div>
+      </a>
       <div
         className="c20"
       >

--- a/src/components/List/__tests__/__snapshots__/SectionItem.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/SectionItem.spec.js.snap
@@ -49,7 +49,7 @@ exports[`<SectionItem /> renders SectionItem correctly 1`] = `
 
 exports[`<SectionItem /> renders SectionItem with children correctly 1`] = `
 <div
-  class="sc-iAyFgw dIlXGo"
+  class="sc-iAyFgw dtkVED"
 >
   <div
     aria-label="Section Item"

--- a/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> removes the Modal on clicking cancel button 1`] = `"<div class=\\"sc-dnqmqq bIqV sc-gzVnrw cCLaVU\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-gZMcBi jgmQkD sc-htoDjs egKJJZ\\"><button class=\\"button--close sc-bZQynM fiacze\\" size=\\"45\\" aria-label=\\"Close Modal\\" role=\\"button\\"><svg viewBox=\\"0 0 12 12\\" width=\\"12\\" height=\\"12\\" fill=\\"rgba(0, 0, 15, 1)\\"><path d=\\"M6.563 6.203l4.523 4.516a.384.384 0 0 1 .117.281c0 .11-.039.203-.117.281a.378.378 0 0 1-.137.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.136-.09L6 6.766 1.484 11.28a.378.378 0 0 1-.136.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.137-.09A.384.384 0 0 1 .797 11c0-.11.039-.203.117-.281l4.524-4.516L.913 1.68a.384.384 0 0 1-.117-.282c0-.109.039-.203.117-.28A.388.388 0 0 1 1.2 1c.112 0 .207.04.285.117L6 5.633l4.516-4.516A.388.388 0 0 1 10.8 1c.112 0 .207.04.285.117a.384.384 0 0 1 .117.281c0 .11-.039.204-.117.282L6.562 6.203z\\"></path></svg></button></div><div class=\\"sc-iwsKbI jOaiji\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
+exports[`<Modal /> removes the Modal on clicking cancel button 1`] = `"<div class=\\"sc-dnqmqq fkdVSA sc-gzVnrw cCLaVU\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-gZMcBi jgmQkD sc-htoDjs egKJJZ\\"><button class=\\"button--close sc-bZQynM fiacze\\" size=\\"45\\" aria-label=\\"Close Modal\\" role=\\"button\\"><svg viewBox=\\"0 0 12 12\\" width=\\"12\\" height=\\"12\\" fill=\\"rgba(0, 0, 15, 1)\\"><path d=\\"M6.563 6.203l4.523 4.516a.384.384 0 0 1 .117.281c0 .11-.039.203-.117.281a.378.378 0 0 1-.137.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.136-.09L6 6.766 1.484 11.28a.378.378 0 0 1-.136.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.137-.09A.384.384 0 0 1 .797 11c0-.11.039-.203.117-.281l4.524-4.516L.913 1.68a.384.384 0 0 1-.117-.282c0-.109.039-.203.117-.28A.388.388 0 0 1 1.2 1c.112 0 .207.04.285.117L6 5.633l4.516-4.516A.388.388 0 0 1 10.8 1c.112 0 .207.04.285.117a.384.384 0 0 1 .117.281c0 .11-.039.204-.117.282L6.562 6.203z\\"></path></svg></button></div><div class=\\"sc-iwsKbI jOaiji\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
 
 exports[`<Modal /> renders Modal correctly 1`] = `
 <div
   aria-modal="true"
-  class="sc-dnqmqq bIqV sc-gzVnrw cCLaVU"
+  class="sc-dnqmqq fkdVSA sc-gzVnrw cCLaVU"
   role="dialog"
 >
   <div

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -17,6 +17,7 @@ const ModalContainer = styled(Column)`
   border: solid 1px rgba(0, 0, 0, 0.04);
   padding: 0;
   overflow-y: scroll;
+  overflow-x: hidden;
   max-height: calc(100% - 96px);
   z-index: 100;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
On the ListRow, add the functionality to show either title or subtitle in the expanded view based ont he parameters passed. Also, disable horizontal scrolling in the modal.
<!-- Why are these changes necessary? -->

**Why**:
Design requirements.
<!-- How were these changes implemented? -->

**How**:
For ListRow, added an additional parameter onExpandShow which accepts the value of either "title" or "subTitle". Based on this value, show either title or subtitle in the expanded view of the listrow.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [X] Documentation
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
