### PR TITLE
fix(modal & sectionItem): set overflow-y to auto in modla and cursor …

### DIFF
--- a/src/components/List/SectionItem.js
+++ b/src/components/List/SectionItem.js
@@ -12,7 +12,7 @@ const ItemContainer = styled.div.attrs({
   display: flex;
   flex-direction: row;
   align-items: center;
-  cursor: ${props => (props.onItemClick ? "pointer" : "default")};
+  cursor: ${props => (props.onItemClick ? "pointer" : "text")};
 
   &:not(:last-of-type) {
     margin-bottom: ${spacing.moderate};

--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -32,7 +32,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -185,7 +185,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -447,7 +447,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -600,7 +600,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -862,7 +862,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -1015,7 +1015,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -1286,7 +1286,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -1439,7 +1439,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -1701,7 +1701,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -1854,7 +1854,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -2116,7 +2116,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -2269,7 +2269,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -2540,7 +2540,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -2693,7 +2693,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -2955,7 +2955,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -3108,7 +3108,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -3370,7 +3370,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -3523,7 +3523,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -3794,7 +3794,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -3947,7 +3947,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -4209,7 +4209,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -4362,7 +4362,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -4624,7 +4624,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -4777,7 +4777,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -5048,7 +5048,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -5204,7 +5204,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
             </div>
             <div
               aria-label="Section Item"
-              class="sc-fMiknA section-item eNjwym"
+              class="sc-fMiknA section-item fkSVxI"
               role="link"
             >
               <div
@@ -5299,7 +5299,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -5452,7 +5452,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -5714,7 +5714,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -5867,7 +5867,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -6129,7 +6129,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -6282,7 +6282,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -6552,7 +6552,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -6705,7 +6705,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -6967,7 +6967,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -7120,7 +7120,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -7382,7 +7382,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -7535,7 +7535,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         </div>
         <div
           aria-label="Section Item"
-          class="sc-fMiknA section-item eNjwym"
+          class="sc-fMiknA section-item fkSVxI"
           role="link"
         >
           <div
@@ -7806,7 +7806,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -7959,7 +7959,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -8221,7 +8221,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -8374,7 +8374,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -8636,7 +8636,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
         </button>
         <a
           aria-label="See Tickets"
-          class="sc-hSdWYo lmmHvK"
+          class="sc-hSdWYo NAqMK"
           href="/"
           role="link"
         >
@@ -8789,7 +8789,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           </div>
           <div
             aria-label="Section Item"
-            class="sc-fMiknA section-item eNjwym"
+            class="sc-fMiknA section-item fkSVxI"
             role="link"
           >
             <div
@@ -9059,7 +9059,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -9182,7 +9182,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >
@@ -9305,7 +9305,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
       </button>
       <a
         aria-label="See Tickets"
-        class="sc-hSdWYo lmmHvK"
+        class="sc-hSdWYo NAqMK"
         href="/"
         role="link"
       >

--- a/src/components/List/__tests__/__snapshots__/ListRowOverflow.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/ListRowOverflow.spec.js.snap
@@ -127,7 +127,7 @@ exports[`<ListRowOverflow /> renders ListRowOverflow correctly 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: default;
+  cursor: text;
 }
 
 .c11:not(:last-of-type) {

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -359,11 +359,11 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
   }
 
   .c5:hover .text--primary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--secondary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--primary:before {
@@ -1039,11 +1039,11 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
   }
 
   .c5:hover .text--primary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--secondary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--primary:before {
@@ -1751,11 +1751,11 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
   }
 
   .c5:hover .text--primary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--secondary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--primary:before {
@@ -2374,11 +2374,11 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
   }
 
   .c5:hover .text--primary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--secondary:after {
-    background-color: rgba(2,108,223,0.01);
+    background-color: rgba(2,108,223,0.1);
   }
 
   .c5:hover .text--primary:before {

--- a/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> removes the Modal on clicking cancel button 1`] = `"<div class=\\"sc-dnqmqq fkdVSA sc-gzVnrw cCLaVU\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-gZMcBi jgmQkD sc-htoDjs egKJJZ\\"><button class=\\"button--close sc-bZQynM fiacze\\" size=\\"45\\" aria-label=\\"Close Modal\\" role=\\"button\\"><svg viewBox=\\"0 0 12 12\\" width=\\"12\\" height=\\"12\\" fill=\\"rgba(0, 0, 15, 1)\\"><path d=\\"M6.563 6.203l4.523 4.516a.384.384 0 0 1 .117.281c0 .11-.039.203-.117.281a.378.378 0 0 1-.137.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.136-.09L6 6.766 1.484 11.28a.378.378 0 0 1-.136.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.137-.09A.384.384 0 0 1 .797 11c0-.11.039-.203.117-.281l4.524-4.516L.913 1.68a.384.384 0 0 1-.117-.282c0-.109.039-.203.117-.28A.388.388 0 0 1 1.2 1c.112 0 .207.04.285.117L6 5.633l4.516-4.516A.388.388 0 0 1 10.8 1c.112 0 .207.04.285.117a.384.384 0 0 1 .117.281c0 .11-.039.204-.117.282L6.562 6.203z\\"></path></svg></button></div><div class=\\"sc-iwsKbI jOaiji\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
+exports[`<Modal /> removes the Modal on clicking cancel button 1`] = `"<div class=\\"sc-dnqmqq dKIBcM sc-gzVnrw cCLaVU\\" role=\\"dialog\\" aria-modal=\\"true\\"><div class=\\"sc-gZMcBi jgmQkD sc-htoDjs egKJJZ\\"><button class=\\"button--close sc-bZQynM fiacze\\" size=\\"45\\" aria-label=\\"Close Modal\\" role=\\"button\\"><svg viewBox=\\"0 0 12 12\\" width=\\"12\\" height=\\"12\\" fill=\\"rgba(0, 0, 15, 1)\\"><path d=\\"M6.563 6.203l4.523 4.516a.384.384 0 0 1 .117.281c0 .11-.039.203-.117.281a.378.378 0 0 1-.137.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.136-.09L6 6.766 1.484 11.28a.378.378 0 0 1-.136.09.417.417 0 0 1-.297 0 .378.378 0 0 1-.137-.09A.384.384 0 0 1 .797 11c0-.11.039-.203.117-.281l4.524-4.516L.913 1.68a.384.384 0 0 1-.117-.282c0-.109.039-.203.117-.28A.388.388 0 0 1 1.2 1c.112 0 .207.04.285.117L6 5.633l4.516-4.516A.388.388 0 0 1 10.8 1c.112 0 .207.04.285.117a.384.384 0 0 1 .117.281c0 .11-.039.204-.117.282L6.562 6.203z\\"></path></svg></button></div><div class=\\"sc-iwsKbI jOaiji\\"><div>Europe</div><div>Africa</div><div>Asias</div></div></div>"`;
 
 exports[`<Modal /> renders Modal correctly 1`] = `
 <div
   aria-modal="true"
-  class="sc-dnqmqq fkdVSA sc-gzVnrw cCLaVU"
+  class="sc-dnqmqq dKIBcM sc-gzVnrw cCLaVU"
   role="dialog"
 >
   <div

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -16,7 +16,7 @@ const ModalContainer = styled(Column)`
   box-shadow: 0 16px 16px 0 rgba(0, 0, 0, 0.06), 0 0 16px 0 rgba(0, 0, 0, 0.12);
   border: solid 1px rgba(0, 0, 0, 0.04);
   padding: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   max-height: calc(100% - 96px);
   z-index: 100;

--- a/src/components/Text/__tests__/__snapshots__/Base.spec.js.snap
+++ b/src/components/Text/__tests__/__snapshots__/Base.spec.js.snap
@@ -5,7 +5,7 @@ exports[`BaseText should render disabled text with a div tag in an accent varian
   font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
-  color: rgba(2,108,223,0.01);
+  color: rgba(2,108,223,0.1);
 }
 
 <div

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -2,7 +2,7 @@ const colors = {
   azure: {
     base: "rgba(2, 108, 223, 1)",
     light: "rgba(2, 108, 223, 0.2)",
-    muted: "rgba(2, 108, 223, 0.01)"
+    muted: "rgba(2, 108, 223, 0.1)"
   },
   summerSky: "#3AC7FF",
   blackPearl: "#1F262D",


### PR DESCRIPTION
…to text if link is not clicabke in SectionItem

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Set overflow-y to auto instead of scroll in Modal. Change the hover color to opacity 0.1 instead of 0.2.
<!-- Why are these changes necessary? -->

**Why**:
scrollbar was showing up even though content was not scrollable. hover color change is design requirement.
<!-- How were these changes implemented? -->

**How**:
Set overflow-y to auto instead of scroll in Modal. Change the hover color to opacity 0.1 instead of 0.2.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [X] Tests
* [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
