### PR TITLE
refactor(Text): unwrap text components to expose styled-components' API

### DIFF
--- a/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Container.spec.js.snap
@@ -41,6 +41,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -135,6 +136,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -232,6 +234,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -294,6 +297,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -369,6 +373,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -456,6 +461,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -550,6 +556,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -647,6 +654,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -709,6 +717,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -784,6 +793,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -871,6 +881,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -965,6 +976,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -1062,6 +1074,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -1124,6 +1137,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -1199,6 +1213,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -1295,6 +1310,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -1389,6 +1405,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -1486,6 +1503,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -1548,6 +1566,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -1623,6 +1642,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -1710,6 +1730,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -1804,6 +1825,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -1901,6 +1923,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -1963,6 +1986,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -2038,6 +2062,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -2125,6 +2150,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -2219,6 +2245,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -2316,6 +2343,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -2378,6 +2406,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -2453,6 +2482,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -2549,6 +2579,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -2643,6 +2674,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -2740,6 +2772,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -2802,6 +2835,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -2877,6 +2911,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -2964,6 +2999,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -3058,6 +3094,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -3155,6 +3192,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -3217,6 +3255,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -3292,6 +3331,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -3379,6 +3419,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -3473,6 +3514,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -3570,6 +3612,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -3632,6 +3675,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -3707,6 +3751,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -3803,6 +3848,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -3897,6 +3943,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -3994,6 +4041,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -4056,6 +4104,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -4131,6 +4180,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -4218,6 +4268,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -4312,6 +4363,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -4409,6 +4461,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -4471,6 +4524,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -4546,6 +4600,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -4633,6 +4688,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -4727,6 +4783,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -4824,6 +4881,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -4886,6 +4944,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -4961,6 +5020,7 @@ exports[`<ListContainer /> closes the bottomSheet for the row when clicked on cr
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -5057,6 +5117,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -5154,6 +5215,7 @@ exports[`<ListContainer /> closes the modal when clicked on an expanded item on 
             >
               <div
                 class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+                color=""
               >
                 Ticket Options
               </div>
@@ -5308,6 +5370,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -5402,6 +5465,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -5499,6 +5563,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -5561,6 +5626,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -5636,6 +5702,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -5723,6 +5790,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -5817,6 +5885,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -5914,6 +5983,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -5976,6 +6046,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -6051,6 +6122,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -6138,6 +6210,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -6232,6 +6305,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -6329,6 +6403,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -6391,6 +6466,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -6466,6 +6542,7 @@ exports[`<ListContainer /> collapses the listRow when clicked on collapse button
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -6561,6 +6638,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -6655,6 +6733,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -6752,6 +6831,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -6814,6 +6894,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -6889,6 +6970,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -6976,6 +7058,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -7070,6 +7153,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -7167,6 +7251,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -7229,6 +7314,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -7304,6 +7390,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -7391,6 +7478,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -7485,6 +7573,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Ticket Options
           </div>
@@ -7582,6 +7671,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Venue Info
           </div>
@@ -7644,6 +7734,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             Lineup
           </div>
@@ -7719,6 +7810,7 @@ exports[`<ListContainer /> expands the listRow when clicked on expand button 1`]
         >
           <div
             class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+            color=""
           >
             More
           </div>
@@ -7815,6 +7907,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -7909,6 +8002,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -8006,6 +8100,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -8068,6 +8163,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -8143,6 +8239,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -8230,6 +8327,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -8324,6 +8422,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -8421,6 +8520,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -8483,6 +8583,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -8558,6 +8659,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -8645,6 +8747,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-dxgOiQ jwaoTg"
+              color=""
               style="text-transform: uppercase;"
             >
               apr 23
@@ -8739,6 +8842,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Ticket Options
             </div>
@@ -8836,6 +8940,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Venue Info
             </div>
@@ -8898,6 +9003,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               Lineup
             </div>
@@ -8973,6 +9079,7 @@ exports[`<ListContainer /> opens the bottomSheet for the row when clicked on ove
           >
             <div
               class="sc-fBuWsC dcpErj sc-dxgOiQ jwaoTg"
+              color=""
             >
               More
             </div>
@@ -9068,6 +9175,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -9191,6 +9299,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23
@@ -9314,6 +9423,7 @@ exports[`<ListContainer /> renders ListContainer correctly without any expanded 
         >
           <div
             class="sc-dxgOiQ jwaoTg"
+            color=""
             style="text-transform: uppercase;"
           >
             apr 23

--- a/src/components/List/__tests__/__snapshots__/ListRowOverflow.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/ListRowOverflow.spec.js.snap
@@ -212,7 +212,7 @@ exports[`<ListRowOverflow /> renders ListRowOverflow correctly 1`] = `
     >
       <div
         className="c5 c6"
-        color={null}
+        color=""
       >
         Ticket Options
       </div>
@@ -312,7 +312,7 @@ exports[`<ListRowOverflow /> renders ListRowOverflow correctly 1`] = `
     >
       <div
         className="c5 c6"
-        color={null}
+        color=""
       >
         Venue Info
       </div>
@@ -376,7 +376,7 @@ exports[`<ListRowOverflow /> renders ListRowOverflow correctly 1`] = `
     >
       <div
         className="c5 c6"
-        color={null}
+        color=""
       >
         Lineup
       </div>
@@ -454,7 +454,7 @@ exports[`<ListRowOverflow /> renders ListRowOverflow correctly 1`] = `
     >
       <div
         className="c5 c6"
-        color={null}
+        color=""
       >
         More
       </div>

--- a/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
+++ b/src/components/List/__tests__/__snapshots__/Row.spec.js.snap
@@ -490,7 +490,7 @@ exports[`<ListRow /> renders List Row with colored date correctly 1`] = `
         >
           <div
             className="c7"
-            color={null}
+            color=""
             style={
               Object {
                 "textTransform": "uppercase",
@@ -1176,7 +1176,7 @@ exports[`<ListRow /> renders List Row with link correctly 1`] = `
         >
           <div
             className="c7"
-            color={null}
+            color=""
             style={
               Object {
                 "textTransform": "uppercase",
@@ -1888,7 +1888,7 @@ exports[`<ListRow /> renders List Row with variant withLink correctly 1`] = `
         >
           <div
             className="c7"
-            color={null}
+            color=""
             style={
               Object {
                 "textTransform": "uppercase",
@@ -2505,7 +2505,7 @@ exports[`<ListRow /> renders standard List Row correctly 1`] = `
         >
           <div
             className="c7"
-            color={null}
+            color=""
             style={
               Object {
                 "textTransform": "uppercase",

--- a/src/components/Text/BoldText.js
+++ b/src/components/Text/BoldText.js
@@ -1,11 +1,9 @@
-import React from "react";
 import PropTypes from "prop-types";
-
 import { colors, typography } from "../../theme";
 import constants from "../../theme/constants";
 import StyledText from "./StyledText";
 
-const BoldStyledText = StyledText.extend`
+const BoldText = StyledText.extend`
   color: ${props => props.color || colors.onyx.base};
   font-weight: ${typography.weight.semiBold};
 
@@ -14,18 +12,11 @@ const BoldStyledText = StyledText.extend`
   }
 `;
 
-const BoldText = ({ color, children, ...rest }) => (
-  <BoldStyledText color={color} {...rest}>
-    {children}
-  </BoldStyledText>
-);
-
 BoldText.defaultProps = {
-  color: null
+  color: ""
 };
 
 BoldText.propTypes = {
-  children: PropTypes.string.isRequired,
   color: PropTypes.string
 };
 

--- a/src/components/Text/PrimaryText.js
+++ b/src/components/Text/PrimaryText.js
@@ -1,24 +1,13 @@
-import React from "react";
-import PropTypes from "prop-types";
-
 import { colors, typography } from "../../theme";
 import constants from "../../theme/constants";
 import StyledText from "./StyledText";
 
-const PrimaryStyledText = StyledText.extend`
+const PrimaryText = StyledText.extend`
   color: ${colors.onyx.base};
 
   @media only screen and ${constants.breakpoints.smallAndUp} {
     font-size: ${typography.size.kilo};
   }
 `;
-
-const PrimaryText = ({ children, ...props }) => (
-  <PrimaryStyledText {...props}>{children}</PrimaryStyledText>
-);
-
-PrimaryText.propTypes = {
-  children: PropTypes.string.isRequired
-};
 
 export default PrimaryText;

--- a/src/components/Text/SecondaryText.js
+++ b/src/components/Text/SecondaryText.js
@@ -1,19 +1,8 @@
-import React from "react";
-import PropTypes from "prop-types";
-
 import { colors } from "../../theme";
 import StyledText from "./StyledText";
 
-const SecondaryStyledText = StyledText.extend`
+const SecondaryText = StyledText.extend`
   color: ${colors.onyx.light};
 `;
-
-const SecondaryText = ({ children, ...props }) => (
-  <SecondaryStyledText {...props}>{children}</SecondaryStyledText>
-);
-
-SecondaryText.propTypes = {
-  children: PropTypes.string.isRequired
-};
 
 export default SecondaryText;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Removing functional components put around styled text components.

<!-- Why are these changes necessary? -->

**Why**:
Would like to expose the API which allows to extend the styled components
<!-- How were these changes implemented? -->

**How**:
Removed wrappers to export Styled Components as is
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation N/A
* [x] Tests N/A
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
