### PR TITLE
feat(Image): Change background-image: contain to background-image: cover

### DIFF
--- a/src/components/Image/Responsive.styles.js
+++ b/src/components/Image/Responsive.styles.js
@@ -10,7 +10,7 @@ const StyledResponsiveImage = styled.div.attrs({
   padding-top: ${({ height, width }) => `${(height / width) * 100}%`};
   background-image: ${({ image }) => `url(${image})`};
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
 `;
 
 StyledResponsiveImage.propTypes = {

--- a/src/components/Image/__tests__/__snapshots__/Responsive.spec.js.snap
+++ b/src/components/Image/__tests__/__snapshots__/Responsive.spec.js.snap
@@ -10,7 +10,7 @@ exports[`ResponsiveImage should render correctly 1`] = `
   padding-top: 56.25%;
   background-image: url(http://placekitten.com/g/826/465);
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
 }
 
 .c1 {


### PR DESCRIPTION
This change is needed so the images' right side won't get chopped off

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: In the StyledResponsiveImage component the background-image: contain property got replaced with background-image: cover

<!-- Why are these changes necessary? -->

**Why**: This change was needed so the right side of the images won't get chopped off.

<!-- How were these changes implemented? -->

**How**: Changed the style of the component.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
