### PR TITLE
feat(Text): allow for h3-6 headings in Text component

### DIFF
--- a/src/components/Text/Base.js
+++ b/src/components/Text/Base.js
@@ -48,7 +48,7 @@ const TextBase = ({
 };
 
 TextBase.propTypes = {
-  tag: PropTypes.oneOf(["div", "span", "p"]),
+  tag: PropTypes.oneOf(["div", "span", "p", "h3", "h4", "h5", "h6"]),
   variant: PropTypes.oneOf(["accent", "dark", "light"]),
   accent: PropTypes.oneOf([
     "",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added h3-6 headings to the list of allowed tags in the Text component.
<!-- Why are these changes necessary? -->

**Why**:
Would like to expand the usage of Text component with those tags

<!-- How were these changes implemented? -->

**How**:
Updated propTypes
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation N/A
* [x] Tests N/A
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
