### PR TITLE
fix(HeaderWithImage): Padding for xlarge screen & breakpoint update

### DIFF
--- a/src/components/Header/WithImage.js
+++ b/src/components/Header/WithImage.js
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import Gradient from "../Gradient";
 import Container from "../Grid/Container";
 import Row from "../Grid/Row";
-import { smallAndUp } from "../../theme/mediaQueries";
+import { mediumAndUp, xLargeAndUp } from "../../theme/mediaQueries";
 
 const GradientBackground = Gradient.extend`
   position: absolute;
@@ -37,10 +37,14 @@ const ContainerRow = styled(Row)`
   align-items: center;
   position: relative;
   z-index: 2;
+  ${xLargeAndUp`
+    padding-left: 72px;
+    padding-right: 72px;
+  `};
 `;
 
 const ImageWrapper = styled.div`
-  ${smallAndUp`
+  ${mediumAndUp`
       padding-top: 60px;
     `};
 `;

--- a/src/components/Header/__tests__/__snapshots__/WithImage.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/WithImage.spec.js.snap
@@ -152,7 +152,14 @@ exports[`WithImage renders header background image 1`] = `
   }
 }
 
-@media screen and (min-width:480px) {
+@media screen and (min-width:1440px) {
+  .c4 {
+    padding-left: 72px;
+    padding-right: 72px;
+  }
+}
+
+@media screen and (min-width:768px) {
   .c7 {
     padding-top: 60px;
   }
@@ -376,7 +383,14 @@ exports[`WithImage renders header background image correctly when a withOverlay 
   }
 }
 
-@media screen and (min-width:480px) {
+@media screen and (min-width:1440px) {
+  .c4 {
+    padding-left: 72px;
+    padding-right: 72px;
+  }
+}
+
+@media screen and (min-width:768px) {
   .c7 {
     padding-top: 60px;
   }
@@ -600,7 +614,14 @@ exports[`WithImage renders header background image correctly when a withUnderlay
   }
 }
 
-@media screen and (min-width:480px) {
+@media screen and (min-width:1440px) {
+  .c4 {
+    padding-left: 72px;
+    padding-right: 72px;
+  }
+}
+
+@media screen and (min-width:768px) {
   .c7 {
     padding-top: 60px;
   }
@@ -822,7 +843,14 @@ exports[`WithImage renders header with image 1`] = `
   }
 }
 
-@media screen and (min-width:480px) {
+@media screen and (min-width:1440px) {
+  .c4 {
+    padding-left: 72px;
+    padding-right: 72px;
+  }
+}
+
+@media screen and (min-width:768px) {
   .c7 {
     padding-top: 60px;
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Updated left & right padding for HeaderWithImage to match spec
- Updated image padding to apply to correct screen sizes after breakpoint update

**Why**:

- Breakpoint changes changed some of the padding & max width for header
- Missed padding requirement on first round
<!-- How were these changes implemented? -->


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
