### PR TITLE
fix(Spacing): fix fallback strategy for padding bottom in large sc…

### DIFF
--- a/src/components/Spacing.js
+++ b/src/components/Spacing.js
@@ -38,7 +38,7 @@ const Spacing = styled.div`
         props.bottom.large ||
           props.bottom.medium ||
           props.bottom.small ||
-          props.top.xSmall
+          props.bottom.xSmall
       )}
   `};
 `;


### PR DESCRIPTION
**What**:

Hot fix for Spacing component to use bottom.xSmall prop as fallback strategy when other sizes are not available and the screen is >=1024

**Why**:

This is the correct prop to fallback

**How**:

Changing props.top.xSmall to props.bottom.xSmall in the media query for large screens

**Checklist**:

* [N/A] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

