### PR TITLE
fix(input-page): Fix input page blowing up with error

### DIFF
--- a/catalog/pages/inputs/index.md
+++ b/catalog/pages/inputs/index.md
@@ -309,8 +309,8 @@ rows:
     Notes: Can be top or left
   - Prop: variant
     Type: string
-    Default: 0
-    Notes: one of (0: border or 1: no-border
+    Default: 0:border
+    Notes: One of 0:border or 1:no-border
   - Prop: value
     Type: string
     Default: N/A


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: A fix was introduced on the Input page.

<!-- Why are these changes necessary? -->

**Why**: Without the fix when you click on the Input menu item in the catalog the whole page blows up.

<!-- How were these changes implemented? -->

**How**: It seems that Catalog cannot handle spaces in the Notes when you are defining the possible values for a given prop.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
