### PR TITLE
feat(DropDownGroup): add containerOverride prop

### DIFF
--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -31,7 +31,8 @@ class DropDownGroup extends React.Component {
   static LAYOUT_VARIANTS = LAYOUT_VARIANTS;
 
   componentDidMount() {
-    document.addEventListener("click", this.handleOutsideClick);
+    const container = this.props.containerOverride || document;
+    container.addEventListener("click", this.handleOutsideClick);
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -58,7 +59,8 @@ class DropDownGroup extends React.Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener("click", this.handleOutsideClick);
+    const container = this.props.containerOverride || document;
+    container.removeEventListener("click", this.handleOutsideClick);
   }
 
   onClick = () => {
@@ -396,7 +398,8 @@ DropDownGroup.propTypes = {
   onDropDownToggle: PropTypes.func,
   hybrid: PropTypes.bool,
   dropdownMenuOpen: PropTypes.func,
-  dropdownMenuClose: PropTypes.func
+  dropdownMenuClose: PropTypes.func,
+  containerOverride: PropTypes.node,
 };
 
 DropDownGroup.defaultProps = {

--- a/src/components/Input/DropDown/DropDownGroup.js
+++ b/src/components/Input/DropDown/DropDownGroup.js
@@ -399,7 +399,7 @@ DropDownGroup.propTypes = {
   hybrid: PropTypes.bool,
   dropdownMenuOpen: PropTypes.func,
   dropdownMenuClose: PropTypes.func,
-  containerOverride: PropTypes.node,
+  containerOverride: PropTypes.node
 };
 
 DropDownGroup.defaultProps = {
@@ -422,7 +422,8 @@ DropDownGroup.defaultProps = {
   onDropDownToggle: null,
   hybrid: false,
   dropdownMenuOpen: null,
-  dropdownMenuClose: null
+  dropdownMenuClose: null,
+  containerOverride: null
 };
 
 export default DropDownGroup;


### PR DESCRIPTION
**What**:

We are using the DropDownGroup component in a custom element under a shadow root, which makes the event listening on 'document' impossible.

**Why**:

To keep using the Aurora DropDownGroup component in our app.

**How**:

Added a containerOverride prop which, when set, will override the default DOM 'document'.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

This shouldn't change existing behavior.